### PR TITLE
(maint) - Handle modules that have no changes to commit

### DIFF
--- a/lib/pdksync.rb
+++ b/lib/pdksync.rb
@@ -149,7 +149,8 @@ module PdkSync
     else
       puts 'PDK Update has run.'
     end
-    status
+    return status unless status == 0 && _stdout.include?("No changes required.")
+    puts "No commits since last run."
   end
 
   # @summary


### PR DESCRIPTION
This handles a scenario where a pdk update has ran on a module and there is nothing to commit.

Before these changes:

``` 
➜  pdksync git:(master) ✗ bundle exec rake pdksync
Beginning pdksync run
Client login has been successful.
*************************************
Syncing puppetlabs-testing1
Cleaning your environment.
Cloning to: puppetlabs-testing1 to modules_pdksync/puppetlabs-testing1.
PDK Update has run.
Rubocop has run successfully.
Creating a branch called: pdksync_1.5.0-0-gd1b3eca.
All files have been staged.
rake aborted!
Git::GitExecuteError: git '--git-dir=/Users/paula/workspace/pdksync/modules_pdksync/puppetlabs-testing1/.git' '--work-tree=/Users/paula/workspace/pdksync/modules_pdksync/puppetlabs-testing1' commit '--message=pdksync_1.5.0-0-gd1b3eca'  2>&1:On branch pdksync_1.5.0-0-gd1b3eca
nothing to commit, working tree clean
/Users/paula/workspace/pdksync/.bundle/gems/ruby/2.3.0/gems/git-1.4.0/lib/git/lib.rb:956:in `command'
/Users/paula/workspace/pdksync/.bundle/gems/ruby/2.3.0/gems/git-1.4.0/lib/git/lib.rb:557:in `commit'
/Users/paula/workspace/pdksync/.bundle/gems/ruby/2.3.0/gems/git-1.4.0/lib/git/base.rb:293:in `commit'
/Users/paula/workspace/pdksync/lib/pdksync.rb:223:in `commit_staged_files'
/Users/paula/workspace/pdksync/lib/pdksync.rb:102:in `sync'
/Users/paula/workspace/pdksync/lib/pdksync.rb:49:in `block in run_pdksync'
/Users/paula/workspace/pdksync/lib/pdksync.rb:46:in `each'
/Users/paula/workspace/pdksync/lib/pdksync.rb:46:in `run_pdksync'
/Users/paula/workspace/pdksync/Rakefile:5:in `block in <top (required)>'
/Users/paula/workspace/pdksync/.bundle/gems/ruby/2.3.0/gems/rake-12.3.1/exe/rake:27:in `<top (required)>'
/Users/paula/.rbenv/versions/2.3.1/bin/bundle:30:in `block in <main>'
/Users/paula/.rbenv/versions/2.3.1/bin/bundle:22:in `<main>'
Tasks: TOP => pdksync
(See full trace by running task with --trace)
➜  pdksync git:(master) ✗
```

After these changes:
```
➜  pdksync git:(master) ✗ bundle exec rake pdksync
Beginning pdksync run
Client login has been successful.
*************************************
Syncing puppetlabs-testing1
Cleaning your environment.
Cloning to: puppetlabs-testing1 to modules_pdksync/puppetlabs-testing1.
PDK Update has run.
No commits since last run.
```