### PR TITLE
Update travis and change ssh to https for git clone

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,25 @@
-language: ruby
+---
 sudo: false
+dist: trusty
+language: ruby
+cache: bundler
 before_install:
-  - gem install bundler
+  - bundle -v
+  - rm -f Gemfile.lock
+  - gem update --system
+  - gem --version
+  - bundle -v
 script:
-  - "bundle exec $CHECK"
-notifications:
-  email: false
+  - 'bundle exec $CHECK'
 rvm:
   - 2.4.1
-  - 2.3.3
-
-env:
-  - "CHECK='rspec spec'"
-  - "CHECK=rubocop"
+matrix:
+  fast_finish: true
+  include:
+    - env: CHECK='rubocop'
+    - env: CHECK='rspec spec'
+branches:
+  only:
+    - master
+    - /^v\d/
+    - release

--- a/lib/pdksync.rb
+++ b/lib/pdksync.rb
@@ -127,7 +127,7 @@ module PdkSync
   #   A git object representing the local repository.
   def self.clone_directory(namespace, module_name, output_path)
     puts "Cloning #{module_name} to #{output_path}."
-    Git.clone("git@github.com:#{namespace}/#{module_name}.git", output_path.to_s) # is returned
+    Git.clone("https://github.com/#{namespace}/#{module_name}.git", output_path.to_s) # is returned
   rescue Git::GitExecuteError
     puts "(FAILURE) Cloning #{module_name} has failed - check the module name and namespace are correct."
   end


### PR DESCRIPTION
The ssh clone was failing due to the repo now being made public, updated to run with http to get tests running again.
Also updated the .travis file to conform to norms.