### PR TITLE
(MODULES-7233) - Add configurable file option

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,21 @@ The following rake tasks are available with pdksync:
   - `rake 'pdksync[MODULES-8231]'` PR title outputs as `pdksync - MODULES-8231 - pdksync_heads/master-0-gabccfb1`
 - `run_a_command[:command]` Run a command against modules eg rake 'run_a_command[complex command here -f -gx]'
 
+### Configuration File
+
+By default pdksync will use hardcoded values for configuring itself however if you wish to supply your own configuration, simply create `$HOME/.pdksync.yml` and use the following format:
+```
+---
+namespace: 'puppetlabs'
+pdksync_dir: 'modules_pdksync'
+push_file_destination: 'origin'
+create_pr_against: 'master'
+managed_modules: 'managed_modules.yml'
+pdksync_label: 'maintenance'
+```
+
+Ensure all the stated fields are present with values.
+
 ### Workflow
 --------
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ This module runs through a pre-set array of modules, with this array set within 
 - puppetlabs-mysql
 ```
 
-To add a module, add it to the list. To remove a module, remove it from the list. If you wish to specify a managed modules file outside of the repo, use the `managed_modules` property in your configuration file to specify the path.
+To add a module, add it to the list. To remove a module, remove it from the list. If you wish to specify a custom managed modules file, use the `managed_modules` property in your configuration file to specify the path to the file.
 
 ### Migrating from modulesync to pdksync
 --------

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Table of Contents
 1. [Overview](#overview)
 2. [Usage](#usage)
 3. [How it works](#how-it-works)
-4. [Installing](#installing)
+4. [Configuration](#configuration)
 5. [Workflow](#workflow)
 6. [Migrating from modulesync to pdksync](#migrating-from-modulesync-to-pdksync)
 7. [Contributing](#contributing)
@@ -44,6 +44,7 @@ The gem takes in a file, `managed_modules.yml`, stored within the gem that lists
 By default, pdksync will supply a label to a PR (default is 'maintenance'). This can be changed by opening `lib/pdksync/constants.rb` and modifying the `PDKSYNC_LABEL` constant. You must ensure that the label selected exists on the modules that you are applying pdksync to. Should you wish to disable this feature, simply change `PDKSYNC_LABEL` to an empty string i.e. ''. Similarly, when supplying a label using the `git:push_and_create_pr` rake task, the label must exist on each of the managed modules to run successfully.
 
 The following rake tasks are available with pdksync:
+- `show_config` Display the current configuration of pdksync
 - `git:clone_managed_modules` Clone managed modules.
 - `git:create_commit[:branch_name, :commit_message]` Stage commits for modules, branchname and commit message eg rake 'git:create_commit[flippity, commit messagez]'.
 - `git:push_and_create_pr[:pr_title, :label]` Push commit, and create PR for modules. Label is optional eg rake 'git:push_and_create_pr[pr title goes here, optional label right here]'.
@@ -55,9 +56,9 @@ The following rake tasks are available with pdksync:
   - `rake 'pdksync[MODULES-8231]'` PR title outputs as `pdksync - MODULES-8231 - pdksync_heads/master-0-gabccfb1`
 - `run_a_command[:command]` Run a command against modules eg rake 'run_a_command[complex command here -f -gx]'
 
-### Configuration File
+### Configuration
 
-By default pdksync will use hardcoded values for configuring itself however if you wish to supply your own configuration, simply create `$HOME/.pdksync.yml` and use the following format:
+By default pdksync will use hardcoded values for configuring itself however if you wish to override these values, simply create `$HOME/.pdksync.yml` and use the following format:
 ```
 ---
 namespace: 'puppetlabs'
@@ -68,7 +69,7 @@ managed_modules: 'managed_modules.yml'
 pdksync_label: 'maintenance'
 ```
 
-Ensure all the stated fields are present with values.
+You may override any property. Those that are not specified in your config file will use their corresponding default value from `constants.rb`.
 
 ### Workflow
 --------
@@ -86,7 +87,8 @@ This module runs through a pre-set array of modules, with this array set within 
 - puppetlabs-stdlib
 - puppetlabs-mysql
 ```
-To add a module, add it to the list. To remove a module, remove it from the list.
+
+To add a module, add it to the list. To remove a module, remove it from the list. If you wish to specify a managed modules file outside of the repo, use the `managed_modules` property in your configuration file to specify the path.
 
 ### Migrating from modulesync to pdksync
 --------

--- a/Rakefile
+++ b/Rakefile
@@ -2,7 +2,7 @@ require_relative 'lib/pdksync'
 require 'colorize'
 require 'github_changelog_generator/task'
 
-desc 'Display the configuration of pdksync'
+desc 'Display the current configuration of pdksync'
 task :show_config do
   include PdkSync::Constants
   puts 'PDKSync Configuration'.bold.yellow

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,18 @@
 require_relative 'lib/pdksync'
+require 'colorize'
 require 'github_changelog_generator/task'
+
+desc 'Display the configuration of pdksync'
+task :show_config do
+  include PdkSync::Constants
+  puts 'PDKSync Configuration'.bold.yellow
+  puts '- Namespace: '.bold + "#{PdkSync::Constants::NAMESPACE}".cyan
+  puts '- PDKSync Dir: '.bold + "#{PdkSync::Constants::PDKSYNC_DIR}".cyan
+  puts '- Push File Destination: '.bold + "#{PdkSync::Constants::PUSH_FILE_DESTINATION}".cyan
+  puts '- Create PR Against: '.bold + "#{PdkSync::Constants::CREATE_PR_AGAINST}".cyan
+  puts '- Managed Modules: '.bold + "#{PdkSync::Constants::MANAGED_MODULES}".cyan
+  puts '- Default PDKSync Label: '.bold + "#{PdkSync::Constants::PDKSYNC_LABEL}".cyan
+end
 
 desc 'Run full pdksync process, clone repository, pdk update, create pr. Additional title information can be added to the title, which will be appended before the reference section.'
 task :pdksync, [:additional_title] do |task, args|

--- a/lib/pdksync/constants.rb
+++ b/lib/pdksync/constants.rb
@@ -20,19 +20,25 @@ module PdkSync # rubocop:disable Style/ClassAndModuleChildren
     config = {}
 
     config_path = "#{ENV['HOME']}/.pdksync.yml"
+
     if File.exist?(config_path)
       config = YAML.load_file(config_path)
+      config["namespace"] ||= default_config[:namespace]
+      config["pdksync_dir"] ||= default_config[:pdksync_dir]
+      config["push_file_destination"] ||= default_config[:push_file_destination]
+      config["create_pr_against"] ||= default_config[:create_pr_against]
+      config["managed_modules"] ||= default_config[:managed_modules]
+      config["pdksync_label"] ||= default_config[:pdksync_label]
     else
-      puts "Could not load configuration file '#{config_path}'\nUsing default configuration..."
       config = default_config
     end
 
     ACCESS_TOKEN = ENV['GITHUB_TOKEN'].freeze
-    NAMESPACE = config[:namespace].freeze
-    PDKSYNC_DIR = config[:pdksync_dir].freeze
-    PUSH_FILE_DESTINATION = config[:push_file_destination].freeze
-    CREATE_PR_AGAINST = config[:create_pr_against].freeze
-    MANAGED_MODULES = config[:managed_modules].freeze
-    PDKSYNC_LABEL = config[:pdksync_label].freeze
+    NAMESPACE = config["namespace"].freeze
+    PDKSYNC_DIR = config["pdksync_dir"].freeze
+    PUSH_FILE_DESTINATION = config["push_file_destination"].freeze
+    CREATE_PR_AGAINST = config["create_pr_against"].freeze
+    MANAGED_MODULES = config["managed_modules"].freeze
+    PDKSYNC_LABEL = config["pdksync_label"].freeze
   end
 end

--- a/lib/pdksync/constants.rb
+++ b/lib/pdksync/constants.rb
@@ -6,6 +6,7 @@ require 'yaml'
 #   Configuration is loaded from `$HOME/.pdksync.yml`. If $HOME is not set, the config_path will use the current directory.
 #   Set PDKSYNC_LABEL to '' to disable adding a label during pdksync runs.
 module PdkSync # rubocop:disable Style/ClassAndModuleChildren
+  # Constants contains the configuration for pdksync to use
   module Constants
     default_config = {
       namespace: 'puppetlabs',

--- a/lib/pdksync/constants.rb
+++ b/lib/pdksync/constants.rb
@@ -22,13 +22,13 @@ module PdkSync # rubocop:disable Style/ClassAndModuleChildren
     config_path = "#{ENV['HOME']}/.pdksync.yml"
 
     if File.exist?(config_path)
-      customConfig = YAML.load_file(config_path)
-      config[:namespace] = customConfig['namespace'] ||= default_config[:namespace]
-      config[:pdksync_dir] = customConfig['pdksync_dir'] ||= default_config[:pdksync_dir]
-      config[:push_file_destination] = customConfig['push_file_destination'] ||= default_config[:push_file_destination]
-      config[:create_pr_against] = customConfig['create_pr_against'] ||= default_config[:create_pr_against]
-      config[:managed_modules] = customConfig['managed_modules'] ||= default_config[:managed_modules]
-      config[:pdksync_label] = customConfig['pdksync_label'] ||= default_config[:pdksync_label]
+      custom_config = YAML.load_file(config_path)
+      config[:namespace] = custom_config['namespace'] ||= default_config[:namespace]
+      config[:pdksync_dir] = custom_config['pdksync_dir'] ||= default_config[:pdksync_dir]
+      config[:push_file_destination] = custom_config['push_file_destination'] ||= default_config[:push_file_destination]
+      config[:create_pr_against] = custom_config['create_pr_against'] ||= default_config[:create_pr_against]
+      config[:managed_modules] = custom_config['managed_modules'] ||= default_config[:managed_modules]
+      config[:pdksync_label] = custom_config['pdksync_label'] ||= default_config[:pdksync_label]
     else
       config = default_config
     end

--- a/lib/pdksync/constants.rb
+++ b/lib/pdksync/constants.rb
@@ -1,14 +1,39 @@
+require 'yaml'
+
 # @summary
 #   A module used to contain a set of variables that are expected to remain constant across all iterations of the main pdksync module.
+# @note
+#   Configuration is loaded from `$HOME/.pdksync.yml`. If $HOME is not set, the config_path will use the current directory.
+#   Set PDKSYNC_LABEL to '' to disable adding a label during pdksync runs.
 module PdkSync # rubocop:disable Style/ClassAndModuleChildren
   module Constants
+
+    default_config = {
+      :namespace => 'puppetlabs',
+      :pdksync_dir => 'modules_pdksync',
+      :push_file_destination => 'origin',
+      :create_pr_against => 'master',
+      :managed_modules => 'managed_modules.yml',
+      :pdksync_label => 'maintenance',
+    }
+
+    config = {}
+
+    config_path = "#{ENV['HOME']}/.pdksync.yml"
+    if File.exists?(config_path)
+      config = YAML.load_file(config_path)
+    else
+      puts "Could not load configuration file '#{config_path}'\nUsing default configuration..."
+      config = default_config
+    end
+
     ACCESS_TOKEN = ENV['GITHUB_TOKEN'].freeze
-    NAMESPACE = 'puppetlabs'.freeze
-    PDKSYNC_DIR = 'modules_pdksync'.freeze
-    PUSH_FILE_DESTINATION = 'origin'.freeze
-    CREATE_PR_AGAINST = 'master'.freeze
-    MANAGED_MODULES = 'managed_modules.yml'.freeze
-    # Set PDKSYNC_LABEL to '' to disable adding a label during pdksync runs
-    PDKSYNC_LABEL = 'maintenance'.freeze
+    NAMESPACE = config[:namespace].freeze
+    PDKSYNC_DIR = config[:pdksync_dir].freeze
+    PUSH_FILE_DESTINATION = config[:push_file_destination].freeze
+    CREATE_PR_AGAINST = config[:create_pr_against].freeze
+    MANAGED_MODULES = config[:managed_modules].freeze
+    PDKSYNC_LABEL = config[:pdksync_label].freeze
+
   end
 end

--- a/lib/pdksync/constants.rb
+++ b/lib/pdksync/constants.rb
@@ -22,23 +22,23 @@ module PdkSync # rubocop:disable Style/ClassAndModuleChildren
     config_path = "#{ENV['HOME']}/.pdksync.yml"
 
     if File.exist?(config_path)
-      config = YAML.load_file(config_path)
-      config["namespace"] ||= default_config[:namespace]
-      config["pdksync_dir"] ||= default_config[:pdksync_dir]
-      config["push_file_destination"] ||= default_config[:push_file_destination]
-      config["create_pr_against"] ||= default_config[:create_pr_against]
-      config["managed_modules"] ||= default_config[:managed_modules]
-      config["pdksync_label"] ||= default_config[:pdksync_label]
+      customConfig = YAML.load_file(config_path)
+      config[:namespace] = customConfig['namespace'] ||= default_config[:namespace]
+      config[:pdksync_dir] = customConfig['pdksync_dir'] ||= default_config[:pdksync_dir]
+      config[:push_file_destination] = customConfig['push_file_destination'] ||= default_config[:push_file_destination]
+      config[:create_pr_against] = customConfig['create_pr_against'] ||= default_config[:create_pr_against]
+      config[:managed_modules] = customConfig['managed_modules'] ||= default_config[:managed_modules]
+      config[:pdksync_label] = customConfig['pdksync_label'] ||= default_config[:pdksync_label]
     else
       config = default_config
     end
 
     ACCESS_TOKEN = ENV['GITHUB_TOKEN'].freeze
-    NAMESPACE = config["namespace"].freeze
-    PDKSYNC_DIR = config["pdksync_dir"].freeze
-    PUSH_FILE_DESTINATION = config["push_file_destination"].freeze
-    CREATE_PR_AGAINST = config["create_pr_against"].freeze
-    MANAGED_MODULES = config["managed_modules"].freeze
-    PDKSYNC_LABEL = config["pdksync_label"].freeze
+    NAMESPACE = config[:namespace].freeze
+    PDKSYNC_DIR = config[:pdksync_dir].freeze
+    PUSH_FILE_DESTINATION = config[:push_file_destination].freeze
+    CREATE_PR_AGAINST = config[:create_pr_against].freeze
+    MANAGED_MODULES = config[:managed_modules].freeze
+    PDKSYNC_LABEL = config[:pdksync_label].freeze
   end
 end

--- a/lib/pdksync/constants.rb
+++ b/lib/pdksync/constants.rb
@@ -7,20 +7,19 @@ require 'yaml'
 #   Set PDKSYNC_LABEL to '' to disable adding a label during pdksync runs.
 module PdkSync # rubocop:disable Style/ClassAndModuleChildren
   module Constants
-
     default_config = {
-      :namespace => 'puppetlabs',
-      :pdksync_dir => 'modules_pdksync',
-      :push_file_destination => 'origin',
-      :create_pr_against => 'master',
-      :managed_modules => 'managed_modules.yml',
-      :pdksync_label => 'maintenance',
+      namespace: 'puppetlabs',
+      pdksync_dir: 'modules_pdksync',
+      push_file_destination: 'origin',
+      create_pr_against: 'master',
+      managed_modules: 'managed_modules.yml',
+      pdksync_label: 'maintenance'
     }
 
     config = {}
 
     config_path = "#{ENV['HOME']}/.pdksync.yml"
-    if File.exists?(config_path)
+    if File.exist?(config_path)
       config = YAML.load_file(config_path)
     else
       puts "Could not load configuration file '#{config_path}'\nUsing default configuration..."
@@ -34,6 +33,5 @@ module PdkSync # rubocop:disable Style/ClassAndModuleChildren
     CREATE_PR_AGAINST = config[:create_pr_against].freeze
     MANAGED_MODULES = config[:managed_modules].freeze
     PDKSYNC_LABEL = config[:pdksync_label].freeze
-
   end
 end


### PR DESCRIPTION
This change allows a user to define their own configuration file that lives outside of the repo, instead of having to manually change hardcoded values in constants.rb