### PR TITLE
(MODULES-7192) - Improved error message for incorrect formatting

### DIFF
--- a/lib/pdksync.rb
+++ b/lib/pdksync.rb
@@ -198,6 +198,7 @@ module PdkSync
   #   String array of the names of GitHub repos
   def self.validate_modules_exist(module_names)
     invalid_names = []
+    raise "Error reading in modules. Check syntax of '#{@managed_modules}'." unless module_names.nil? && module_names.is_a?(Array)
     module_names.each do |module_name|
       # If module name is invalid, push it to invalid names array
       unless Octokit.repository?("#{@namespace}/#{module_name}")

--- a/spec/lib/pdksync_spec.rb
+++ b/spec/lib/pdksync_spec.rb
@@ -14,6 +14,7 @@ describe PdkSync do
 
   before(:each) do
     allow(PdkSync).to receive(:return_modules).and_return(@module_names)
+    allow(PdkSync).to receive(:validate_modules_exist).and_return(@module_names)
     Dir.chdir(@folder)
   end
 


### PR DESCRIPTION
Incorrect formatting of managed_modules can return the following error: 

```NoMethodError: undefined method `each' for "-pu":String```

This change implements a more verbose error stating the root issue.