### PR TITLE
(MODULES-8419) Refactor to add support for GitLab

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,6 +6,11 @@ desc 'Display the current configuration of pdksync'
 task :show_config do
   include PdkSync::Constants
   puts 'PDKSync Configuration'.bold.yellow
+  puts '- Git hosting platform: '.bold + "#{PdkSync::Constants::GIT_PLATFORM}".cyan
+  puts '- Git base URI: '.bold + "#{PdkSync::Constants::GIT_BASE_URI}".cyan
+  if PdkSync::Constants::GIT_PLATFORM == :gitlab
+    puts '- Gitlab API endpoint: '.bold + "#{PdkSync::Constants::GITLAB_API_ENDPOINT}".cyan
+  end
   puts '- Namespace: '.bold + "#{PdkSync::Constants::NAMESPACE}".cyan
   puts '- PDKSync Dir: '.bold + "#{PdkSync::Constants::PDKSYNC_DIR}".cyan
   puts '- Push File Destination: '.bold + "#{PdkSync::Constants::PUSH_FILE_DESTINATION}".cyan
@@ -23,7 +28,7 @@ task :pdksync, [:additional_title] do |task, args|
   PdkSync::main(steps: [:use_pdk_ref, :clone, :pdk_update, :create_commit, :push_and_create_pr], args: args)
 end
 
-namespace :pdk do 
+namespace :pdk do
   desc 'Runs PDK convert against modules'
   task :pdk_convert do
     PdkSync::main(steps: [:pdk_convert])

--- a/lib/pdksync/constants.rb
+++ b/lib/pdksync/constants.rb
@@ -14,14 +14,20 @@ module PdkSync # rubocop:disable Style/ClassAndModuleChildren
       push_file_destination: 'origin',
       create_pr_against: 'master',
       managed_modules: 'managed_modules.yml',
-      pdksync_label: 'maintenance'
+      pdksync_label: 'maintenance',
+      git_platform: :github,
+      git_base_uri: 'https://github.com',
+      gitlab_api_endpoint: 'https://gitlab.com/api/v4'
     }
+
+    supported_git_platforms = [:github, :gitlab]
 
     config = {}
 
     config_path = "#{ENV['HOME']}/.pdksync.yml"
 
-    if File.exist?(config_path)
+    # pdksync config file must exist, not be empty and not be an empty YAML file
+    if File.exist?(config_path) && YAML.load_file(config_path) && !YAML.load_file(config_path).nil?
       custom_config = YAML.load_file(config_path)
       config[:namespace] = custom_config['namespace'] ||= default_config[:namespace]
       config[:pdksync_dir] = custom_config['pdksync_dir'] ||= default_config[:pdksync_dir]
@@ -29,16 +35,44 @@ module PdkSync # rubocop:disable Style/ClassAndModuleChildren
       config[:create_pr_against] = custom_config['create_pr_against'] ||= default_config[:create_pr_against]
       config[:managed_modules] = custom_config['managed_modules'] ||= default_config[:managed_modules]
       config[:pdksync_label] = custom_config['pdksync_label'] ||= default_config[:pdksync_label]
+      config[:git_platform] = custom_config['git_platform'] ||= default_config[:git_platform]
+      config[:git_base_uri] = custom_config['git_base_uri'] ||= case config[:git_platform]
+                                                                when :gitlab
+                                                                  'https://gitlab.com'
+                                                                else
+                                                                  default_config[:git_base_uri]
+                                                                end
+      config[:gitlab_api_endpoint] = custom_config['gitlab_api_endpoint'] ||= default_config[:gitlab_api_endpoint]
     else
       config = default_config
     end
 
-    ACCESS_TOKEN = ENV['GITHUB_TOKEN'].freeze
     NAMESPACE = config[:namespace].freeze
     PDKSYNC_DIR = config[:pdksync_dir].freeze
     PUSH_FILE_DESTINATION = config[:push_file_destination].freeze
     CREATE_PR_AGAINST = config[:create_pr_against].freeze
     MANAGED_MODULES = config[:managed_modules].freeze
     PDKSYNC_LABEL = config[:pdksync_label].freeze
+    GIT_PLATFORM = config[:git_platform].downcase.to_sym.freeze
+    GIT_BASE_URI = config[:git_base_uri].freeze
+    GITLAB_API_ENDPOINT = config[:gitlab_api_endpoint].freeze
+    ACCESS_TOKEN = case GIT_PLATFORM
+                   when :github
+                     ENV['GITHUB_TOKEN'].freeze
+                   when :gitlab
+                     ENV['GITLAB_TOKEN'].freeze
+                   end
+
+    # Sanity checks
+
+    unless supported_git_platforms.include?(GIT_PLATFORM)
+      raise "Unsupported Git hosting platform '#{GIT_PLATFORM}'."\
+        " Supported platforms are: #{supported_git_platforms.join(', ')}"
+    end
+
+    if ACCESS_TOKEN.nil?
+      raise "Git platform access token for #{GIT_PLATFORM.capitalize} not set"\
+        " - use 'export #{GIT_PLATFORM.upcase}_TOKEN=\"<your token>\"' to set"
+    end
   end
 end

--- a/lib/pdksync/githubclient.rb
+++ b/lib/pdksync/githubclient.rb
@@ -1,0 +1,75 @@
+require 'octokit'
+
+# @summary
+#   This class wraps Octokit::Client and provides the method implementations
+#   required by pdksync main to access the Github API for creating pull
+#   requests, adding labels, and so forth.
+class PdkSync::GithubClient
+  # @summary
+  #   Creates a new Octokit::Client and logs in the user based on the
+  #   supplied access token
+  # @param access_token
+  #   The Github access token, required to access the Github API
+  def initialize(access_token)
+    @client = Octokit::Client.new(access_token: access_token.to_s)
+    @client.user.login
+  end
+
+  # @summary Checks if the supplied repository exists on the Git hosting platform
+  # @param [String] repository
+  #   The full repository name, i.e. "namespace/repo_name"
+  # @return [Boolean] true if the repository exists, false otherwise
+  def repository?(repository)
+    @client.repository?(repository)
+  end
+
+  # @summary Creates a new pull request against the Git hosting platform
+  # @param [String] repo_name
+  #   The full repository name, i.e. "namespace/repo_name" in which to create
+  #   the pull request
+  # @param [String] create_pr_against
+  #   The target branch against which to create the pull request
+  # @param [String] head
+  #   The source branch from which to create the pull request
+  # @param [String] title
+  #   The title/name of the pull request to create
+  # @param [String] message
+  #   The pull request message/body
+  # @return An Octokit pull request object for the newly created pull request
+  def create_pull_request(repo_name, create_pr_against, head, title, message)
+    @client.create_pull_request(repo_name, create_pr_against, head, title, message)
+  end
+
+  # @summary Gets the labels available in the repository
+  # @param [String] repo_name
+  #   The full repository name, i.e. "namespace/repo_name", from which to get
+  #   the available labels
+  # @return [Array] List of available labels in the repository
+  def labels(repo_name)
+    @client.labels(repo_name)
+  end
+
+  # @summary Updates an existing issue/pull request in the repository
+  # @param [String] repo_name
+  #   The full repository name, i.e. "namespace/repo_name" in which to update
+  #   the issue
+  # @param [Integer] issue_number
+  #   The id number of the issue/pull request to update
+  # @param [Hash] options
+  #   A hash of options definint the changes to the issue
+  # @return An Octokit issue object of the updated issue
+  def update_issue(repo_name, issue_number, options)
+    @client.update_issue(repo_name, issue_number, options)
+  end
+
+  # @summary Deletes a branch in the repository
+  # @param [String] repo_name
+  #   The full repository name, i.e. "namespace/repo_name" in which to delete
+  #   the branch
+  # @param [String] branch_name
+  #   The name of the branch to delete
+  # @return [Boolean] true on success, false on failure
+  def delete_branch(repo_name, branch_name)
+    @client.delete_branch(repo_name, branch_name)
+  end
+end

--- a/lib/pdksync/gitlabclient.rb
+++ b/lib/pdksync/gitlabclient.rb
@@ -1,0 +1,91 @@
+require 'gitlab'
+
+# @summary
+#   This class wraps Gitlab::Client and provides the method implementations
+#   required by pdksync main to access the Gitlab API for creating merge
+#   requests, adding labels, and so forth.
+class PdkSync::GitlabClient
+  # @summary
+  #   Creates a new Gitlab::Client and logs in the user based on the
+  #   supplied access token and the Gitlab API endpoint URL
+  # @param [String] access_token
+  #   The Gitlab private access token, required to access the Gitlab API
+  # @param [String] gitlab_api_endpoint
+  #   URL to the Gitlab API endpoint against which to work
+  def initialize(access_token, gitlab_api_endpoint)
+    @client = Gitlab.client(endpoint: gitlab_api_endpoint, private_token: access_token)
+  end
+
+  # @summary Checks if the supplied project exists on the Git hosting platform
+  # @param [String] project
+  #   The full repository name, i.e. "namespace/project"
+  # @return [Boolean] true if the project exists, false otherwise
+  def repository?(project)
+    @client.project(project)
+
+    true
+  rescue Gitlab::Error::NotFound
+    false
+  end
+
+  # @summary
+  #   Creates a new merge request (i.e. pull request) against the Gitlab
+  #   platform
+  # @param [String] project
+  #   The full project name, i.e. "namespace/project" in which to create
+  #   the merge request
+  # @param [String] target_branch
+  #   The target branch against which to create the merge request
+  # @param [String] source_branch
+  #   The source branch from which to create the merge request
+  # @param [String] title
+  #   The title/name of the merge request to create
+  # @param [String] message
+  #   The pull request message/body
+  # @return
+  #   A Gitlab merge request object for the newly created merge request
+  def create_pull_request(project, target_branch, source_branch, title, message)
+    mr_options = {
+      source_branch: source_branch,
+      target_branch: target_branch,
+      description: message
+    }
+    @client.create_merge_request(project, title, mr_options)
+  end
+
+  # @summary Gets the labels available in the project
+  # @param [String] project
+  #   The full project name, i.e. "namespace/project", from which to get
+  #   the available labels
+  # @return [Array] List of available labels in the project
+  def labels(project)
+    @client.labels(project)
+  end
+
+  # @summary Updates an existing merge request in the repository
+  # @note This method is specifically used to set labels for a merge request
+  # @param [String] project
+  #   The full project name, i.e. "namespace/project" in which to update
+  #   the issue
+  # @param [Integer] id
+  #   The id number of the merge request to update
+  # @param [Hash] options
+  #   A hash of options defining the changes to the merge request
+  # @return A Gitlab merge request object of the updated merge request
+  def update_issue(project, id, options)
+    # Gitlab requires labels to be supplied as a comma-separated string
+    labels = options[:labels].join(',')
+    @client.update_merge_request(project, id, labels: labels)
+  end
+
+  # @summary Deletes a branch in the project
+  # @param [String] project
+  #   The full project name, i.e. "namespace/project" in which to delete
+  #   the branch
+  # @param [String] branch_name
+  #   The name of the branch to delete
+  # @return [Boolean] true on success, false on failure
+  def delete_branch(project, branch_name)
+    @client.delete_branch(project, branch_name)
+  end
+end

--- a/lib/pdksync/gitplatformclient.rb
+++ b/lib/pdksync/gitplatformclient.rb
@@ -1,0 +1,109 @@
+require 'pdksync/pullrequest'
+
+# @summary
+#   The GitPlatformClient class creates a PdkSync::GithubClient or
+#   PdkSync::GitlabClient and provides methods wrapping the client's
+#   corresponding methods
+class PdkSync::GitPlatformClient
+  # @summary
+  #   Creates a PdkSync::GithubClient or PdkSync::GitlabClient based on the
+  #   value of git_platform.
+  # @param [Symbol] git_platform
+  #   The symbol designating the Git hosting platform to use and thus which
+  #   client to create
+  # @param [Hash] git_platform_access_settings
+  #   Hash of Git platform access settings, such as access_token or
+  #   gitlab_api_endpoint. access_token is always required,
+  #   gitlab_api_endpoint only for Gitlab.
+  def initialize(git_platform, git_platform_access_settings)
+    @git_platform = git_platform
+
+    # TODO: raise exceptions when git_platform_access_settings hash is not
+    # set up correctly? Or let PdkSync::GithubClient or PdkSync::GitlabClient
+    # raise errors later and let them propagate upwards?
+    access_token = git_platform_access_settings[:access_token]
+    @client = case git_platform
+              when :github
+                require 'pdksync/githubclient'
+
+                PdkSync::GithubClient.new(access_token)
+              when :gitlab
+                require 'pdksync/gitlabclient'
+
+                gitlab_api_endpoint = git_platform_access_settings[:gitlab_api_endpoint]
+                PdkSync::GitlabClient.new(access_token, gitlab_api_endpoint)
+              end
+  end
+
+  # @summary Checks if the supplied project exists on the Git hosting platform
+  # @param [String] project
+  #   The full repository name, i.e. "namespace/project"
+  # @return [Boolean] true if the project exists, false otherwise
+  def repository?(project)
+    @client.repository?(project)
+  end
+
+  # @summary
+  #   Creates a new pull/merge request against the Git hosting platform and
+  #   wraps the Github or Gitlab result in a PdkSync::PullRequest object for
+  #   consumption by pdksync main
+  # @param [String] project
+  #   The full project name, i.e. "namespace/project" in which to create
+  #   the pull/merge request
+  # @param [String] target_branch
+  #   The target branch against which to create the pull/merge request
+  # @param [String] source_branch
+  #   The source branch from which to create the pull/merge request
+  # @param [String] title
+  #   The title/name of the pull/merge request to create
+  # @param [String] message
+  #   The pull/merge request message/body
+  # @return [PdkSync::PullRequest]
+  #   A pdksync pull request object for the newly created pull/merge request
+  #   for consumption by pdksync main
+  def create_pull_request(project, target_branch, source_branch, title, message)
+    client_pr = @client.create_pull_request(project, target_branch, source_branch, title, message)
+    pr = case @git_platform
+         when :github
+           PdkSync::PullRequest.github(client_pr)
+         when :gitlab
+           PdkSync::PullRequest.gitlab(client_pr)
+         end
+    pr
+  end
+
+  # @summary Gets the labels available in the project
+  # @param [String] project
+  #   The full project name, i.e. "namespace/project", from which to get
+  #   the available labels
+  # @return [Array] List of available labels in the project
+  def labels(project)
+    @client.labels(project)
+  end
+
+  # @summary Updates an existing pull/merge request in the repository
+  # @note
+  #   This method is specifically used to set labels for a pull/merge request
+  # @param [String] project
+  #   The full project name, i.e. "namespace/project" in which to update
+  #   the issue
+  # @param [Integer] id
+  #   The id number of the pull/merge request to update
+  # @param [Hash] options
+  #   A hash of options defining the changes to the pull/merge request
+  # @return A pull/merge request object of the updated pull/merge request
+  def update_issue(project, id, options)
+    @client.update_issue(project, id, options)
+  end
+
+  # @summary Deletes a branch in the project
+  # @param [String] project
+  #   The full project name, i.e. "namespace/project" in which to delete
+  #   the branch
+  # @param [String] branch_name
+  #   The name of the branch to delete
+  # @return [Boolean] true on success, false on failure
+  def delete_branch(project, branch_name)
+    @client.delete_branch(project, branch_name)
+  end
+end

--- a/lib/pdksync/pullrequest.rb
+++ b/lib/pdksync/pullrequest.rb
@@ -1,0 +1,35 @@
+# @summary A simple wrapper class around Github pull request and Gitlab merge
+#   request objects used to abstract the differences and provide a common
+#   interface to PR URL and number/id.
+class PdkSync::PullRequest
+  class << self
+    def github(pr_object)
+      new(pr_object)
+    end
+
+    def gitlab(pr_object)
+      new(pr_object, :gitlab)
+    end
+
+    private :new
+  end
+
+  attr_reader :html_url, :number
+
+  # Create a new PR wrapper object setting html_url and number
+  # @param pr_object
+  #   The pull request object to wrap as created by Octokit::Client or
+  #   Gitlab::Client
+  # @param [Symbol] git_platform
+  #   The Git hosting platform against which the pull request is made
+  def initialize(pr_object, git_platform = :github)
+    case git_platform
+    when :github
+      @html_url = pr_object.html_url
+      @number = pr_object.number
+    when :gitlab
+      @html_url = pr_object.web_url
+      @number = pr_object.iid
+    end
+  end
+end

--- a/pdksync.gemspec
+++ b/pdksync.gemspec
@@ -17,11 +17,12 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'bundler'
+  spec.add_development_dependency 'bundler', '~> 1.15'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'rubocop', '~> 0.50.0'
   spec.add_development_dependency 'octokit'
+  spec.add_development_dependency 'gitlab'
   spec.add_development_dependency 'pry'
 
   spec.add_runtime_dependency 'git', '~>1.3'


### PR DESCRIPTION
* Create a GitPlatformClient wrapper class with the methods required by
  pdksync main
* Keep the interface unchanged, meaning pdksync main uses the same
  methods as before, but now they are no longer Octokit-specific
* Create wrapper classes for Github and Gitlab API access, using
  octokit/octokit.rb for Github and NARKOZ/gitlab for Gitlab
* Create a wrapper class for pull request objects abstracting the
  differences between Github and Gitlab
* Keep Github and the Github API as defaults as before
* Extend configuration and constants for Git platform-specific settings
* Allow the user to configure which Git hosting platform to use
* Allow the user to configure the Git base URI under which to access
  Git repositories
* Set default Git base URI according to configured Git platform
* Add sanity checks to PdkSync::Constants and bail if GITHUB_TOKEN or
  GITLAB_TOKEN are unset, or if an unknown Git platform is
  configured
* Guard against ~/.pdksync.yml being an empty file or an empty YAML
  file. Both cases would result in trying to access non-existent keys,
  leading to failure.
* Constrain bundler to ~> 1.15 in pdksync.gemspec since bundler >= 2.0.0
  introduces some incompatibilities with older Rubygems versions.
* Update README on how to configure pdksync to use GitLab instead of
  GitHub