### PR TITLE
Includes two small cleanup items around messaging

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -30,6 +30,7 @@ namespace :pdksync do
  desc 'Display the current configuration of pdksync'
   task :show_config do
     include PdkSync::Constants
+    puts 'Please note that you can override any of the configuration by using an additional file at `$HOME/.pdksync.yml`.'.bold.red
     puts 'PDKSync Configuration'.bold.yellow
     puts '- Git hosting platform: '.bold + "#{PdkSync::Constants::GIT_PLATFORM}".cyan
     puts '- Git base URI: '.bold + "#{PdkSync::Constants::GIT_BASE_URI}".cyan

--- a/Rakefile
+++ b/Rakefile
@@ -2,23 +2,6 @@ require_relative 'lib/pdksync'
 require 'colorize'
 require 'github_changelog_generator/task'
 
-desc 'Display the current configuration of pdksync'
-task :show_config do
-  include PdkSync::Constants
-  puts 'PDKSync Configuration'.bold.yellow
-  puts '- Git hosting platform: '.bold + "#{PdkSync::Constants::GIT_PLATFORM}".cyan
-  puts '- Git base URI: '.bold + "#{PdkSync::Constants::GIT_BASE_URI}".cyan
-  if PdkSync::Constants::GIT_PLATFORM == :gitlab
-    puts '- Gitlab API endpoint: '.bold + "#{PdkSync::Constants::GITLAB_API_ENDPOINT}".cyan
-  end
-  puts '- Namespace: '.bold + "#{PdkSync::Constants::NAMESPACE}".cyan
-  puts '- PDKSync Dir: '.bold + "#{PdkSync::Constants::PDKSYNC_DIR}".cyan
-  puts '- Push File Destination: '.bold + "#{PdkSync::Constants::PUSH_FILE_DESTINATION}".cyan
-  puts '- Create PR Against: '.bold + "#{PdkSync::Constants::CREATE_PR_AGAINST}".cyan
-  puts '- Managed Modules: '.bold + "#{PdkSync::Constants::MANAGED_MODULES}".cyan
-  puts '- Default PDKSync Label: '.bold + "#{PdkSync::Constants::PDKSYNC_LABEL}".cyan
-end
-
 desc 'Run full pdksync process, clone repository, pdk update, create pr. Additional title information can be added to the title, which will be appended before the reference section.'
 task :pdksync, [:additional_title] do |task, args|
   args = {:branch_name    => "pdksync_{ref}",
@@ -28,7 +11,7 @@ task :pdksync, [:additional_title] do |task, args|
   PdkSync::main(steps: [:use_pdk_ref, :clone, :pdk_update, :create_commit, :push_and_create_pr], args: args)
 end
 
-namespace :pdk do
+namespace :pdksync do
   desc 'Runs PDK convert against modules'
   task :pdk_convert do
     PdkSync::main(steps: [:pdk_convert])
@@ -37,6 +20,28 @@ namespace :pdk do
   desc 'Runs PDK validate against modules'
   task :pdk_validate do
     PdkSync::main(steps: [:pdk_validate])
+  end
+
+  desc "Run a command against modules eg rake 'run_a_command[complex command here -f -gx]'"
+  task :run_a_command, [:command] do |task, args|
+    PdkSync::main(steps: [:run_a_command], args: args[:command])
+  end
+
+ desc 'Display the current configuration of pdksync'
+  task :show_config do
+    include PdkSync::Constants
+    puts 'PDKSync Configuration'.bold.yellow
+    puts '- Git hosting platform: '.bold + "#{PdkSync::Constants::GIT_PLATFORM}".cyan
+    puts '- Git base URI: '.bold + "#{PdkSync::Constants::GIT_BASE_URI}".cyan
+    if PdkSync::Constants::GIT_PLATFORM == :gitlab
+      puts '- Gitlab API endpoint: '.bold + "#{PdkSync::Constants::GITLAB_API_ENDPOINT}".cyan
+    end
+    puts '- Namespace: '.bold + "#{PdkSync::Constants::NAMESPACE}".cyan
+    puts '- PDKSync Dir: '.bold + "#{PdkSync::Constants::PDKSYNC_DIR}".cyan
+    puts '- Push File Destination: '.bold + "#{PdkSync::Constants::PUSH_FILE_DESTINATION}".cyan
+    puts '- Create PR Against: '.bold + "#{PdkSync::Constants::CREATE_PR_AGAINST}".cyan
+    puts '- Managed Modules: '.bold + "#{PdkSync::Constants::MANAGED_MODULES}".cyan
+    puts '- Default PDKSync Label: '.bold + "#{PdkSync::Constants::PDKSYNC_LABEL}".cyan
   end
 end
 
@@ -60,11 +65,6 @@ namespace :git do
   task :clean_branches, [:branch_name]  do |task, args|
     PdkSync::main(steps: [:clean_branches], args: args)
   end
-end
-
-desc "Run a command against modules eg rake 'run_a_command[complex command here -f -gx]'"
-task :run_a_command, [:command] do |task, args|
-  PdkSync::main(steps: [:run_a_command], args: args[:command])
 end
 
 GitHubChangelogGenerator::RakeTask.new :changelog do |config|


### PR DESCRIPTION
Includes:

* An update to the output message of show config
* An update to clean up the namespaces

After this PR the rake task output is like so:
`➜ pdksync git:(smallcleanups) ✗ bundle exec rake -T
rake changelog

rake git:clean_branches[branch_name]

rake git:clone_managed_modules

rake git:create_commit[branch_name,commit_message]

rake git:push_and_create_pr[pr_title,label]

rake pdksync[additional_title]

rake pdksync:pdk_convert

rake pdksync:pdk_validate

rake pdksync:run_a_command[command] '

rake pdksync:show_config `