### PR TITLE
(MODULES-8730) Display warning on outdated pdk version

### DIFF
--- a/lib/pdksync.rb
+++ b/lib/pdksync.rb
@@ -184,14 +184,14 @@ module PdkSync
   # @summary
   #   Check the local pdk version against the most recent tagged release on GitHub
   def self.check_pdk_version
-    _stdout, stderr, status = Open3.capture3("#{return_pdk_path} --version")
+    stdout, _stderr, status = Open3.capture3("#{return_pdk_path} --version")
     raise "(FAILURE) Unable to find pdk at '#{return_pdk_path}'.".red unless status.exitstatus
 
-    local_version = _stdout.strip
+    local_version = stdout.strip
     remote_version = Octokit.tags('puppetlabs/pdk').first[:name][1..-1]
-    
+
     unless Gem::Version.new(remote_version) <= Gem::Version.new(local_version)
-      puts "(WARNING) The current version of pdk is #{remote_version} however you are using #{local_version}".red 
+      puts "(WARNING) The current version of pdk is #{remote_version} however you are using #{local_version}".red
     end
   rescue StandardError => error
     puts "(WARNING) Unable to check latest pdk version. #{error}".red

--- a/lib/pdksync.rb
+++ b/lib/pdksync.rb
@@ -10,6 +10,7 @@ require 'json'
 require 'yaml'
 require 'colorize'
 require 'bundler'
+require 'octokit'
 
 # @summary
 #   This module set's out and controls the pdksync process
@@ -49,6 +50,7 @@ module PdkSync
   }
 
   def self.main(steps: [:clone], args: nil)
+    check_pdk_version
     create_filespace
     client = setup_client
     module_names = return_modules
@@ -177,6 +179,22 @@ module PdkSync
     pr_list.each do |pr|
       puts pr
     end
+  end
+
+  # @summary
+  #   Check the local pdk version against the most recent tagged release on GitHub
+  def self.check_pdk_version
+    _stdout, stderr, status = Open3.capture3("#{return_pdk_path} --version")
+    raise "(FAILURE) Unable to find pdk at '#{return_pdk_path}'.".red unless status.exitstatus
+
+    local_version = _stdout.strip
+    remote_version = Octokit.tags('puppetlabs/pdk').first[:name][1..-1]
+    
+    unless Gem::Version.new(remote_version) <= Gem::Version.new(local_version)
+      puts "(WARNING) The current version of pdk is #{remote_version} however you are using #{local_version}".red 
+    end
+  rescue StandardError => error
+    puts "(WARNING) Unable to check latest pdk version. #{error}".red
   end
 
   # @summary


### PR DESCRIPTION
This change will display a warning to the user if they are found to be using an older version of pdk than the current release.