### PR TITLE
Fix bug with cloning private repositories

### DIFF
--- a/lib/pdksync.rb
+++ b/lib/pdksync.rb
@@ -298,7 +298,10 @@ module PdkSync
   # @return [Git::Base]
   #   A git object representing the local repository.
   def self.clone_directory(namespace, module_name, output_path)
-    Git.clone("#{@git_base_uri}/#{namespace}/#{module_name}.git", output_path.to_s) # is returned
+    # not all urls are public facing so we need to conditionally use the correct separator
+    sep = @git_base_uri.start_with?('git@') ? ':' : '/'
+    clone_url = "#{@git_base_uri}#{sep}#{namespace}/#{module_name}.git"
+    Git.clone(clone_url, output_path.to_s) # is returned
   rescue Git::GitExecuteError => error
     puts "(FAILURE) Cloning #{module_name} has failed. #{error}".red
   end


### PR DESCRIPTION
  * Without this change pdksync assumes all modules are
    public.  This fixes that by checking if the git url
    starts with a git@ pattern and generates a proper url
    like git@github.com:nwops/puppet-private.git instead of
    git@github.com/nwops/puppet-private.git.