### PR TITLE
Adds configurable api endpoint

### DIFF
--- a/lib/pdksync.rb
+++ b/lib/pdksync.rb
@@ -46,7 +46,8 @@ module PdkSync
   @git_base_uri = Constants::GIT_BASE_URI
   @git_platform_access_settings = {
     access_token: Constants::ACCESS_TOKEN,
-    gitlab_api_endpoint: Constants::GITLAB_API_ENDPOINT
+    gitlab_api_endpoint: Constants::GITLAB_API_ENDPOINT,
+    api_endpoint: Constants.API_ENDPOINT
   }
 
   def self.main(steps: [:clone], args: nil)

--- a/lib/pdksync/constants.rb
+++ b/lib/pdksync/constants.rb
@@ -18,6 +18,7 @@ module PdkSync # rubocop:disable Style/ClassAndModuleChildren
       git_platform: :github,
       git_base_uri: 'https://github.com',
       gitlab_api_endpoint: 'https://gitlab.com/api/v4'
+      api_endpoint: nil
     }
 
     supported_git_platforms = [:github, :gitlab]
@@ -29,6 +30,7 @@ module PdkSync # rubocop:disable Style/ClassAndModuleChildren
     # pdksync config file must exist, not be empty and not be an empty YAML file
     if File.exist?(config_path) && YAML.load_file(config_path) && !YAML.load_file(config_path).nil?
       custom_config = YAML.load_file(config_path)
+      config[:api_endpoint] = custom_config['api_endpoint'] || default_config[:api_endpoint]
       config[:namespace] = custom_config['namespace'] ||= default_config[:namespace]
       config[:pdksync_dir] = custom_config['pdksync_dir'] ||= default_config[:pdksync_dir]
       config[:push_file_destination] = custom_config['push_file_destination'] ||= default_config[:push_file_destination]
@@ -56,6 +58,7 @@ module PdkSync # rubocop:disable Style/ClassAndModuleChildren
     GIT_PLATFORM = config[:git_platform].downcase.to_sym.freeze
     GIT_BASE_URI = config[:git_base_uri].freeze
     GITLAB_API_ENDPOINT = config[:gitlab_api_endpoint].freeze
+    API_ENDPOINT = config[:api_endpoint].freeze
     ACCESS_TOKEN = case GIT_PLATFORM
                    when :github
                      ENV['GITHUB_TOKEN'].freeze
@@ -69,7 +72,6 @@ module PdkSync # rubocop:disable Style/ClassAndModuleChildren
       raise "Unsupported Git hosting platform '#{GIT_PLATFORM}'."\
         " Supported platforms are: #{supported_git_platforms.join(', ')}"
     end
-
     if ACCESS_TOKEN.nil?
       raise "Git platform access token for #{GIT_PLATFORM.capitalize} not set"\
         " - use 'export #{GIT_PLATFORM.upcase}_TOKEN=\"<your token>\"' to set"

--- a/lib/pdksync/githubclient.rb
+++ b/lib/pdksync/githubclient.rb
@@ -10,7 +10,9 @@ class PdkSync::GithubClient
   #   supplied access token
   # @param access_token
   #   The Github access token, required to access the Github API
-  def initialize(access_token)
+  def initialize(access_token, api_endpoint = nil)
+    # USE ENV['OCTOKIT_API_ENDPOINT'] or pass in the api_endpoint
+    Octokit.configure { |c| c.api_endpoint = api_endpoint } unless api_endpoint.nil?
     @client = Octokit::Client.new(access_token: access_token.to_s)
     @client.user.login
   end

--- a/lib/pdksync/gitplatformclient.rb
+++ b/lib/pdksync/gitplatformclient.rb
@@ -26,11 +26,11 @@ class PdkSync::GitPlatformClient
               when :github
                 require 'pdksync/githubclient'
 
-                PdkSync::GithubClient.new(access_token)
+                PdkSync::GithubClient.new(access_token, git_platform_access_settings[:api_endpoint])
               when :gitlab
                 require 'pdksync/gitlabclient'
 
-                gitlab_api_endpoint = git_platform_access_settings[:gitlab_api_endpoint]
+                gitlab_api_endpoint = git_platform_access_settings[:gitlab_api_endpoint] || git_platform_access_settings[:api_endpoint]
                 PdkSync::GitlabClient.new(access_token, gitlab_api_endpoint)
               end
   end


### PR DESCRIPTION
* previously if a user was using github enterprise there wasn't a
   easy way to specify the api url for github.  This fixes that
   by adding a api_endpoint configuration option for github and gitlab.

* Github and Gitlab api config has always been separated but they
   don't need to be.  This allows the api_endpoint config to be used
   for both Github and Gitlab and keeps backward compatibility for Gitlab.     