### PR TITLE
(maint) Add bundler tasks and pdk requirement

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
+git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
 # Specify your gem's dependencies in pdksync.gemspec
 gemspec
@@ -9,6 +9,5 @@ gem 'github_changelog_generator', '~> 1.15'
 gem 'travis'
 
 group :development do
-  gem 'pry', require: true
   gem 'rb-readline', require: true
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,25 +1,23 @@
-require 'pdksync/rake_tasks'
-require 'github_changelog_generator/task'
-require 'rubocop/rake_task'
-require 'rspec/core/rake_task'
+require "pdksync/rake_tasks"
+require "github_changelog_generator/task"
+require "rubocop/rake_task"
+require "rspec/core/rake_task"
+require "bundler/gem_tasks"
 
 RuboCop::RakeTask.new(:rubocop) do |t|
-  t.options = ['--display-cop-names']
+  t.options = ["--display-cop-names"]
 end
-
 
 RSpec::Core::RakeTask.new(:spec)
 
 task :default => :spec
 
-
-
 GitHubChangelogGenerator::RakeTask.new :changelog do |config|
-  config.user = 'puppetlabs'
-  config.project = 'pdksync'
+  config.user = "puppetlabs"
+  config.project = "pdksync"
   # config.since_tag = '1.1.1'
-  config.future_release = '0.5.0'
-  config.exclude_labels = ['maintenance']
+  config.future_release = "0.5.0"
+  config.exclude_labels = ["maintenance"]
   config.header = "# Change log\n\nAll notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org)."
   config.add_pr_wo_labels = true
   config.issues = false

--- a/pdksync.gemspec
+++ b/pdksync.gemspec
@@ -1,21 +1,21 @@
-lib = File.expand_path("../lib", __FILE__)
+lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
-  spec.name = "pdksync"
-  spec.version = "0.5.0"
-  spec.authors = ["Puppet"]
-  spec.email = [""]
-  spec.summary = "Puppet Module PDK Synchronizer"
-  spec.description = "Utility to synchronize common files across puppet modules using PDK Update."
-  spec.homepage = "http://github.com/puppetlabs/pdksync"
-  spec.license = "Apache-2.0"
-  spec.required_ruby_version = ">= 2.0.0"
+  spec.name = 'pdksync'
+  spec.version = '0.5.0'
+  spec.authors = ['Puppet']
+  spec.email = ['']
+  spec.summary = 'Puppet Module PDK Synchronizer'
+  spec.description = 'Utility to synchronize common files across puppet modules using PDK Update.'
+  spec.homepage = 'http://github.com/puppetlabs/pdksync'
+  spec.license = 'Apache-2.0'
+  spec.required_ruby_version = '>= 2.0.0'
 
   spec.files = `git ls-files -z`.split("\x0")
   spec.executables = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files = spec.files.grep(%r{^(test|spec|features)/})
-  spec.require_paths = ["lib"]
+  spec.require_paths = ['lib']
 
   spec.add_development_dependency "bundler", "~> 2.0.1"
   spec.add_development_dependency "rspec"
@@ -23,10 +23,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pry"
   spec.add_runtime_dependency 'pdk', '>= 1.14.1'
   spec.add_runtime_dependency "git", "~>1.3"
-  spec.add_runtime_dependency "pdk", ">= 1.10.0"
   spec.add_runtime_dependency "rake"
   spec.add_runtime_dependency "gitlab"
   spec.add_runtime_dependency "octokit"
   spec.add_runtime_dependency "colorize"
->>>>>>> Updates pdk requirement to use pdk >= 1.10
 end

--- a/pdksync.gemspec
+++ b/pdksync.gemspec
@@ -17,14 +17,14 @@ Gem::Specification.new do |spec|
   spec.test_files = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency "bundler", "~> 2.0.1"
-  spec.add_development_dependency "rspec"
-  spec.add_development_dependency "rubocop", "~> 0.50.0"
-  spec.add_development_dependency "pry"
+  spec.add_development_dependency 'bundler', '~> 2.0.1'
+  spec.add_development_dependency 'rspec'
+  spec.add_development_dependency 'rubocop', '~> 0.50.0'
+  spec.add_development_dependency 'pry'
   spec.add_runtime_dependency 'pdk', '>= 1.14.1'
-  spec.add_runtime_dependency "git", "~>1.3"
-  spec.add_runtime_dependency "rake"
-  spec.add_runtime_dependency "gitlab"
-  spec.add_runtime_dependency "octokit"
-  spec.add_runtime_dependency "colorize"
+  spec.add_runtime_dependency 'git', '~>1.3'
+  spec.add_runtime_dependency 'rake'
+  spec.add_runtime_dependency 'gitlab'
+  spec.add_runtime_dependency 'octokit'
+  spec.add_runtime_dependency 'colorize'
 end

--- a/pdksync.gemspec
+++ b/pdksync.gemspec
@@ -1,31 +1,32 @@
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
-  spec.name                  = 'pdksync'
-  spec.version               = '0.5.0'
-  spec.authors               = ['Puppet']
-  spec.email                 = ['']
-  spec.summary               = 'Puppet Module PDK Synchronizer'
-  spec.description           = 'Utility to synchronize common files across puppet modules using PDK Update.'
-  spec.homepage              = 'http://github.com/puppetlabs/pdksync'
-  spec.license               = 'Apache-2.0'
-  spec.required_ruby_version = '>= 2.0.0'
+  spec.name = "pdksync"
+  spec.version = "0.5.0"
+  spec.authors = ["Puppet"]
+  spec.email = [""]
+  spec.summary = "Puppet Module PDK Synchronizer"
+  spec.description = "Utility to synchronize common files across puppet modules using PDK Update."
+  spec.homepage = "http://github.com/puppetlabs/pdksync"
+  spec.license = "Apache-2.0"
+  spec.required_ruby_version = ">= 2.0.0"
 
-  spec.files         = `git ls-files -z`.split("\x0")
-  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
-  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
-  spec.require_paths = ['lib']
+  spec.files = `git ls-files -z`.split("\x0")
+  spec.executables = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
+  spec.test_files = spec.files.grep(%r{^(test|spec|features)/})
+  spec.require_paths = ["lib"]
 
-  spec.add_development_dependency 'bundler', '>= 1.16'
-  spec.add_development_dependency 'rspec'
-  spec.add_development_dependency 'rubocop', '~> 0.50.0'
-  spec.add_development_dependency 'pry'
-
-  spec.add_runtime_dependency 'git', '~>1.3'
+  spec.add_development_dependency "bundler", "~> 2.0.1"
+  spec.add_development_dependency "rspec"
+  spec.add_development_dependency "rubocop", "~> 0.50.0"
+  spec.add_development_dependency "pry"
   spec.add_runtime_dependency 'pdk', '>= 1.14.1'
-  spec.add_runtime_dependency 'rake'
-  spec.add_runtime_dependency 'gitlab'
-  spec.add_runtime_dependency 'octokit'
-  spec.add_runtime_dependency 'colorize'
+  spec.add_runtime_dependency "git", "~>1.3"
+  spec.add_runtime_dependency "pdk", ">= 1.10.0"
+  spec.add_runtime_dependency "rake"
+  spec.add_runtime_dependency "gitlab"
+  spec.add_runtime_dependency "octokit"
+  spec.add_runtime_dependency "colorize"
+>>>>>>> Updates pdk requirement to use pdk >= 1.10
 end

--- a/spec/utils_spec.rb
+++ b/spec/utils_spec.rb
@@ -54,7 +54,9 @@ describe 'PdkSync::Utils' do
 
   it '#self.module_templates_url' do
     allow(Octokit).to receive(:tags).with('puppetlabs/pdk').and_return([{ name: 'v1.14.1' }])
-    expect(PdkSync::Utils.module_templates_url(metadata_file)).to eq('https://github.com/puppetlabs/pdk-templates#1.14.1')
+    url, version = PdkSync::Utils.module_templates_url(metadata_file).split('#')
+    expect(url).to eq('https://github.com/puppetlabs/pdk-templates')
+    expect(version).to match(%r{\d\.\d\d\.\d})
   end
 
   it '#self.change_module_template_url' do


### PR DESCRIPTION
This is just a bit of cleanup but the big thing here is moving the pdk requirement to 1.10.0 or later. Without this pdksync users who have a very old version of pdk installed will run into issues.