### PR TITLE
(maint) 27x performance improvement

### DIFF
--- a/lib/pdksync.rb
+++ b/lib/pdksync.rb
@@ -21,13 +21,15 @@ module PdkSync
     @configuration ||= PdkSync::Configuration.new
   end
 
+  def self.client
+    @client ||= setup_client
+  end
+
   def self.main(steps: [:clone], args: nil)
     check_pdk_version if ENV['PDKSYNC_VERSION_CHECK'].eql?('true')
     create_filespace
-    client = setup_client
     module_names = return_modules
     raise "No modules found in '#{configuration.managed_modules}'" if module_names.nil?
-    validate_modules_exist(client, module_names)
     pr_list = []
 
     # The current directory is saved for cleanup purposes
@@ -62,6 +64,7 @@ module PdkSync
       repo_name = "#{configuration.namespace}/#{module_name}"
       output_path = "#{configuration.pdksync_dir}/#{module_name}"
       if steps.include?(:clone)
+        validate_modules_exist(client, module_names)
         clean_env(output_path) if Dir.exist?(output_path)
         PdkSync::Logger.info 'delete module directory'
         @git_repo = clone_directory(configuration.namespace, module_name, output_path)


### PR DESCRIPTION
By moving the check for module repositories to the `clone` step, we save
22s startup time for all other pdksync commands. Once the repository is
cloned, we do not need additional reassurance that it exists on github.

```
# before
david@davids:~/git/pdksync$ time bundle exec rake 'pdksync:run_a_command[pwd]' > /dev/null

real	0m22.996s
user	0m1.540s
sys	0m0.202s

# after
david@davids:~/git/pdksync$ time bundle exec rake 'pdksync:run_a_command[pwd]' > /dev/null

real	0m0.825s
user	0m0.702s
sys	0m0.133s
david@davids:~/git/pdksync$
```

This change also makes the initialisation of the client optional, so it
does not allocate memory unless it is needed.