### PR TITLE
(maint) Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ pdksync.yml:
 ```yaml
 ---
 namespace: 'YOUR GITHUB NAME'
-git_base_uri: 'git@github.com:'
+git_base_uri: 'git@github.com'
 ```
 
 


### PR DESCRIPTION
The `:` at the end of the `git_base_uri` attribute is not required. Adding it to the `pdksync.yml` results in a remote clone of `git@github.com::$NAMESPACE/$REPO` which fails due to the double `::`