### PR TITLE
Improve spec_helper to avoid test failures

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,10 +1,6 @@
 require 'rspec'
 require 'git'
 require 'fileutils'
-# Set environment variable if it does not exist
-unless ENV['GITHUB_TOKEN']
-  ENV['GITHUB_TOKEN'] = 'github-token'
-end
 
 def pupmods_dir
   @pupmods_dir ||= begin
@@ -32,7 +28,11 @@ def fixtures_dir
 end
 
 RSpec.configure do |config|
-  config.before(:suite) { setup_fake_module }
+  config.before(:suite) do
+    setup_fake_module
+    # provide a fake github token for the tests
+    ENV['GITHUB_TOKEN'] = 'github-token'
+  end
   config.before(:each) do
     allow(PdkSync::Utils.configuration).to receive(:git_base_uri).and_return("file://#{fixtures_dir}")
   end


### PR DESCRIPTION
When a GITHUB_TOKEN was set in the environment, tests would fail with

```
  1) PdkSync::Utils #self.setup_client
     Failure/Error: PdkSync::GitPlatformClient.new(configuration.git_platform, configuration.git_platform_access_settings)
       #<PdkSync::GitPlatformClient (class)> received :new with unexpected arguments
         expected: (:github, {:access_token=>"github-token", :api_endpoint=>nil, :gitlab_api_endpoint=>"https://gitlab.com/api/v4"})
              got: (:github, {:access_token=>"[secure]", :api_endpoint=>nil, :gitlab_api_endpoint=>"https://gitlab.com/api/v4"})
       Diff:
       @@ -1,5 +1,5 @@
        [:github,
       - {:access_token=>"github-token",
       + {:access_token=>"[secure]",
          :api_endpoint=>nil,
          :gitlab_api_endpoint=>"https://gitlab.com/api/v4"}]
     # ./lib/pdksync/utils.rb:341:in `setup_client'
     # ./spec/utils_spec.rb:102:in `block (2 levels) in <top (required)>'
```