### PR TITLE
Add tasks to add / update entries in module's provision.yaml

### DIFF
--- a/lib/pdksync.rb
+++ b/lib/pdksync.rb
@@ -338,6 +338,15 @@ module PdkSync
           PdkSync::Logger.info 'Updated with multigem, '
         end
 
+        if steps.include?(:add_provision_list)
+          result = Utils.add_provision_list(output_path, module_args[:key], module_args[:provisioner], [module_args[:images], module_args.extras].flatten)
+          raise "#{output_path}/provision.yaml does not exist" unless result
+        end
+
+        if steps.include?(:generate_vmpooler_release_checks)
+          Utils.generate_vmpooler_release_checks(output_path, module_args[:puppet_version].to_i)
+        end
+
         PdkSync::Logger.info 'done'
       end
       table = Terminal::Table.new title: 'Module Test Results', headings: %w[Module Status Result From], rows: report_rows

--- a/lib/pdksync/conf/puppet_abs_supported_platforms.yaml
+++ b/lib/pdksync/conf/puppet_abs_supported_platforms.yaml
@@ -1,0 +1,41 @@
+# PUPPET VERSION PLATFORM COMPATIBILITY
+#
+# Define the Puppet version as a root key, then specify the OS platform(s) and versions(s) that this Puppet version is
+# compatible with AND that you wish to test on. If you wish to exclude a platform from testing, simply omit it.
+#
+# OS names and versions must conform to the VMPooler nomenclature and conventions.
+#
+# Running 'bundle exec rake 'pdksync:generate_vmpooler_release_checks[7]' will generate an entry in the 'provision.yaml'
+# for each managed module that contains a configuration that satisfies both:
+# - The module's compatible platforms
+# - The Puppet version's compatible platforms (in this example: '7')
+#
+# NOTE: arch will always be assumed to be 'x86_64'
+---
+5:
+  centos: ['5', '6', '7', '8']
+  debian: ['8', '9', '10']
+  oracle: ['5', '6', '7']
+  redhat: ['5', '6', '7', '8']
+  sles: ['12', '15']
+  scientific: ['6', '7']
+  ubuntu: ['14.04', '16.04', '18.04']
+  win: ['2008r2', '2012r2', '2016', '2019', '10-pro']
+6:
+  centos: ['5', '6', '7', '8']
+  debian: ['8', '9', '10']
+  oracle: ['5', '6', '7']
+  redhat: ['5', '6', '7', '8']
+  sles: ['12', '15']
+  scientific: ['6', '7']
+  ubuntu: ['14.04', '16.04', '18.04', '20.04']
+  win: ['2008r2', '2012r2', '2016', '2019', '10-pro']
+7:
+  centos: ['7', '8']
+  debian: ['9', '10']
+  oracle: ['7']
+  redhat: ['7', '8']
+  sles: ['12', '15']
+  scientific: ['7']
+  ubuntu: ['18.04', '20.04']
+  win: ['2012r2', '2016', '2019', '10-pro']

--- a/lib/pdksync/rake_tasks.rb
+++ b/lib/pdksync/rake_tasks.rb
@@ -87,6 +87,16 @@ namespace :pdksync do
   task :test_results_jenkins, [:jenkins_server_url] do |_task, args|
     PdkSync.main(steps: [:test_results_jenkins], args: args)
   end
+
+  desc 'Add a provision list key to provision.yaml'
+  task :add_provision_list, [:key, :provisioner, :images] do |_task, args|
+    PdkSync.main(steps: [:add_provision_list], args: args)
+  end
+
+  desc 'Generates release checks in provision.yaml based on module compatible platforms and puppet version'
+  task :generate_vmpooler_release_checks, [:puppet_version] do |_task, args|
+    PdkSync.main(steps: [:generate_vmpooler_release_checks], args: args)
+  end
 end
 
 namespace :git do

--- a/lib/pdksync/utils.rb
+++ b/lib/pdksync/utils.rb
@@ -1096,7 +1096,7 @@ module PdkSync
           else
             next unless agent_test_platforms[os].include? ver
             PdkSync::Logger.debug "'#{os} #{ver}' SUPPORTED by Puppet #{puppet_version}"
-            images << "#{os}-#{ver.gsub('.', '')}-x86_64"
+            images << "#{os}-#{ver.delete('.')}-x86_64"
           end
         end
       end


### PR DESCRIPTION
The `pdksync:add_provision_list[:key, :provisioner, :images]` task
will add an entry to the `provision.yaml` with the params given.

The `generate_vmpooler_release_checks[:puppet_version]` task will
create an entry in the `provision.yaml` that will generate a
release checks configuration (using the ABS provisioner) that
satisfies both of these requirements:
- The supported platforms of the given Puppet version
- The supported platforms of the module

This ensures that there is the maximum coverage for each Puppet
version on each module, without any unecessary platforms being
tested.

The Puppet version's test platforms are defined in the config file
`lib/pdksync/conf/puppet_abs_support_platforms.yaml`.