### PR TITLE
(maint) - Remove bootstrap from managed_modules

### DIFF
--- a/managed_modules.yml
+++ b/managed_modules.yml
@@ -8,7 +8,6 @@
 #- puppetlabs-apache
 #- puppetlabs-apt
 #- puppetlabs-azure
-#- puppetlabs-bootstrap
 #- puppetlabs-chocolatey
 #- puppetlabs-concat
 #- puppetlabs-docker


### PR DESCRIPTION
`bootstrap` is no longer supported by the modules team