### PR TITLE
(maint) Removing Azure from managed modules list

### DIFF
--- a/managed_modules.yml
+++ b/managed_modules.yml
@@ -7,7 +7,6 @@
 #- puppetlabs-acl
 #- puppetlabs-apache
 #- puppetlabs-apt
-#- puppetlabs-azure
 #- puppetlabs-chocolatey
 #- puppetlabs-concat
 #- puppetlabs-docker


### PR DESCRIPTION
This module has been deprecated.