### PR TITLE
Revert "(GH-cat-8) Move CentOS 8 support to CentOS Stream 8"

### DIFF
--- a/lib/pdksync/utils.rb
+++ b/lib/pdksync/utils.rb
@@ -1066,9 +1066,7 @@ module PdkSync
       case os
       when %r{aix}i
         'AIX'
-      when %r{centos stream}i
-        'CentOS Stream'
-      when %r{centos\z}i
+      when %r{cent}i
         'CentOS'
       when %r{darwin}i
         'Darwin'


### PR DESCRIPTION
Reverts puppetlabs/pdksync#166