### PR TITLE
(maint) - Removal of modules no longer supported

### DIFF
--- a/managed_modules.yml
+++ b/managed_modules.yml
@@ -1,6 +1,5 @@
 ---
 ## IA content team
-#- cisco_ios
 #- device_manager
 #- provision
 #- puppetlabs-accounts

--- a/managed_modules.yml
+++ b/managed_modules.yml
@@ -16,8 +16,6 @@
 #- puppetlabs-facter_task
 #- puppetlabs-firewall
 #- puppetlabs-haproxy
-#- puppetlabs-helm
-#- puppetlabs-ibm_installation_manager
 #- puppetlabs-iis
 #- puppetlabs-inifile
 #- puppetlabs-java
@@ -27,23 +25,18 @@
 #- puppetlabs-mysql
 #- puppetlabs-ntp
 #- puppetlabs-package
-#- puppetlabs-panos
 #- puppetlabs-postgresql
 #- puppetlabs-powershell
 #- puppetlabs-puppet_conf
 #- puppetlabs-reboot
 #- puppetlabs-registry
-#- puppetlabs-rook
 #- puppetlabs-satellite_pe_tools
 #- puppetlabs-scheduled_task
 #- puppetlabs-service
 #- puppetlabs-sqlserver
 #- puppetlabs-stdlib
-#- puppetlabs-tagmail
 #- puppetlabs-tomcat
 #- puppetlabs-vcsrepo
-#- puppetlabs-vsphere
-#- puppetlabs-websphere_application_server
 #- puppetlabs-wsus_client
 ## testing only
 #- puppetlabs-testing


### PR DESCRIPTION
See additional blog post for more information on the removal of support:
https://puppetlabs.github.io/content-and-tooling-team/blog/posts/2022-06-30-changes-to-supported-modules/