### PR TITLE
Fix `Logger.error`

### DIFF
--- a/lib/pdksync/logger.rb
+++ b/lib/pdksync/logger.rb
@@ -46,7 +46,7 @@ module PdkSync
       logger.fatal(message)
     end
 
-    def self.crit(message)
+    def self.error(message)
       logger.error(message)
     end
 

--- a/lib/pdksync/utils.rb
+++ b/lib/pdksync/utils.rb
@@ -249,7 +249,7 @@ module PdkSync
           stdout, stderr, status = Open3.capture3(command)
         end
         PdkSync::Logger.info "\n#{stdout}\n"
-        PdkSync::Logger.crit "Unable to run command '#{command}': #{stderr}" unless status.exitstatus.zero?
+        PdkSync::Logger.error "Unable to run command '#{command}': #{stderr}" unless status.exitstatus.zero?
         status.exitstatus
       else
         # Environment cleanup required due to Ruby subshells using current Bundler environment


### PR DESCRIPTION
For some reason, there was a `self.crit` method in `logger.rb` (calling `logger.error`), but no `self.error`.

There was only one instance of `Logger.crit` in the code, but three instances of `Logger.error` that would all explode with

```
NoMethodError: undefined method `error' for PdkSync::Logger:Class
```

Fixes #172