### PR TITLE
(maint) Update unit test expectation

### DIFF
--- a/spec/utils_spec.rb
+++ b/spec/utils_spec.rb
@@ -52,7 +52,7 @@ describe 'PdkSync::Utils' do
   end
 
   it '#self.return_template_ref' do
-    expect(PdkSync::Utils.return_template_ref(metadata_file)).to match(%r{tags/})
+    expect(PdkSync::Utils.return_template_ref(metadata_file)).to match(%r{heads/main-0-})
   end
 
   it '#self.module_templates_url' do


### PR DESCRIPTION
Prior to this commit the unit test was failing as the reference on the template has changed. 

Updating the test to be inline with the current test data.

PDKSync is cloning puppetlabs-motd and checking its currently metadata.json file which now looks different from when the initial pdksync tests were written: https://github.com/puppetlabs/puppetlabs-motd/blob/93f8597c24a86df550e8406b62c629d8f215d5bb/metadata.json#L100