### PR TITLE
(maint) Removal of Travis references

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,6 @@ git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 gemspec
 
 gem 'github_changelog_generator', '~> 1.15'
-gem 'travis'
 
 group :development do
   gem 'rb-readline', require: true

--- a/README.md
+++ b/README.md
@@ -544,12 +544,6 @@ Gemfile:
       - gem 'octokit'
         platforms: ruby
 ```
-- Make changes to your travis configuration:
-```yaml
-.travis.yml:
-  branches:
-    - release
-```
 - Delete files that you don't want to exist in the repo:
 ```yaml
 .gitlab-ci.yml:


### PR DESCRIPTION
Prior to this commit, pulling in the Travis gem pulled in a vulnerable version of the active support gem.

This commit removes the travis dependency as it is no longer required.