### PR TITLE
(maint) Removal of old obsolete gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,9 +5,6 @@ git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 # Specify your gem's dependencies in pdksync.gemspec
 gemspec
 
-gem 'github_changelog_generator', '~> 1.15'
-gem 'travis'
-
 group :development do
   gem 'rb-readline', require: true
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,4 @@
 require "pdksync/rake_tasks"
-require "github_changelog_generator/task"
 require "rubocop/rake_task"
 require "rspec/core/rake_task"
 require "bundler/gem_tasks"
@@ -11,29 +10,3 @@ end
 RSpec::Core::RakeTask.new(:spec)
 
 task :default => :spec
-
-GitHubChangelogGenerator::RakeTask.new :changelog do |config|
-  config.user = "puppetlabs"
-  config.project = "pdksync"
-  # config.since_tag = '1.1.1'
-  config.future_release = "0.6.0"
-  config.exclude_labels = ["maintenance"]
-  config.header = "# Change log\n\nAll notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org)."
-  config.add_pr_wo_labels = true
-  config.issues = false
-  config.merge_prefix = "### UNCATEGORIZED PRS; GO LABEL THEM"
-  config.configure_sections = {
-    "Changed" => {
-      "prefix" => "### Changed",
-      "labels" => ["backwards-incompatible"],
-    },
-    "Added" => {
-      "prefix" => "### Added",
-      "labels" => ["feature", "enhancement"],
-    },
-    "Fixed" => {
-      "prefix" => "### Fixed",
-      "labels" => ["bugfix"],
-    },
-  }
-end


### PR DESCRIPTION
## Summary

Prior to this commit we were using old gems that are no longer used. We don't use Travis anymore and also the changelog generator. As they are old dependencies they are brining in a version of activesupport that has a CVE.

Removing the gems will stop us bringing in old dependencies we no longer need.

## Related Issues (if any)
N/A

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
- [x] Manually verified.
