### PR TITLE
(CONT-1138) - Add ruby 3.x compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
       matrix:
         ruby_version:
           - '2.7'
+          - '3.2'
     name: "spec (ruby ${{ matrix.ruby_version }})"
     uses: "puppetlabs/cat-github-actions/.github/workflows/gem_ci.yml@main"
     secrets: "inherit"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -13,6 +13,7 @@ jobs:
       matrix:
         ruby_version:
           - '2.7'
+          - '3.2'
     name: "spec (ruby ${{ matrix.ruby_version }})"
     uses: "puppetlabs/cat-github-actions/.github/workflows/gem_ci.yml@main"
     secrets: "inherit"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,15 @@
 ---
+inherit_from: .rubocop_todo.yml
+
+require:
+- rubocop-performance
+- rubocop-rspec
 AllCops:
+  NewCops: enable
   DisplayCopNames: true
+  ExtraDetails: true
+  DisplayStyleGuide: true
+  TargetRubyVersion: '2.7'
   Include:
     - "./**/*.rb"
   Exclude:
@@ -57,37 +66,6 @@ Style/TrailingCommaInArguments:
 Style/SymbolArray:
   Description: Using percent style obscures symbolic intent of array's contents.
   EnforcedStyle: brackets
-inherit_from: ".rubocop_todo.yml"
-Style/CollectionMethods:
-  Enabled: true
-Style/MethodCalledOnDoEndBlock:
-  Enabled: true
-Style/StringMethods:
-  Enabled: true
-Layout/EndOfLine:
-  Enabled: false
-Metrics/AbcSize:
-  Enabled: false
-Metrics/BlockLength:
-  Enabled: false
-Metrics/ClassLength:
-  Enabled: false
-Metrics/CyclomaticComplexity:
-  Enabled: false
-Metrics/MethodLength:
-  Enabled: false
-Metrics/ModuleLength:
-  Enabled: false
-Metrics/ParameterLists:
-  Enabled: false
-Metrics/PerceivedComplexity:
-  Enabled: false
-Style/AsciiComments:
-  Enabled: false
-Style/IfUnlessModifier:
-  Enabled: false
-Style/SymbolProc:
-  Enabled: false
 Style/Documentation:
   Exclude:
     - lib/pdksync/utils.rb

--- a/Gemfile
+++ b/Gemfile
@@ -10,5 +10,7 @@ group :development do
 end
 
 group :rubocop do
-    gem 'rubocop', '~> 1.6.1', require: false
+    gem 'rubocop', '~> 1.48.1',           require: false
+    gem 'rubocop-rspec', '~> 2.19',       require: false
+    gem 'rubocop-performance', '~> 1.16', require: false
 end

--- a/spec/pdksync_spec.rb
+++ b/spec/pdksync_spec.rb
@@ -9,7 +9,7 @@ describe PdkSync do
     @pdksync_dir = './modules_pdksync'
     @pdksync_gem_dir = './gems_pdksync'
     module_name = 'puppetlabs-motd'
-    gem_name = 'puppet-module-gems'
+    gem_name = 'puppet-strings'
     @module_names = ['puppetlabs-motd']
     @output_path_module = "#{@pdksync_dir}/#{module_name}"
     @output_path_gem = "#{@pdksync_gem_dir}/#{gem_name}"
@@ -161,7 +161,7 @@ describe PdkSync do
       allow(PdkSync::Utils).to receive(:setup_client).and_return(git_client)
       FileUtils.rm_rf(@pdksync_gem_dir)
       PdkSync::Utils.create_filespace_gem
-      PdkSync.main(steps: [:clone_gem], args: { gem_name: 'puppet-module-gems' })
+      PdkSync.main(steps: [:clone_gem], args: { gem_name: 'puppet-strings' })
       expect(Dir.exist?(@pdksync_dir)).to be(true)
       expect(Dir.exist?(@pdksync_gem_dir)).to be(true)
       expect(Dir.exist?(@output_path_gem)).to be(true)
@@ -170,8 +170,8 @@ describe PdkSync do
       expect { PdkSync.main(steps: [:multi_gem_testing]) }.to raise_error(RuntimeError, %r{"multi_gem_testing" requires arguments to run version_file and build_gem})
     end
     it 'runs a command for updating the version and building the gem' do
-      allow(Octokit).to receive(:tags).with('puppetlabs/puppet-module-gems').and_return([{ name: '1' }])
-      PdkSync.main(steps: [:multi_gem_testing], args: { gem_name: 'puppet-module-gems', version_file: 'config/info.yml', build_gem: 'exe/build-gems.rb', gem_path: 'pkg', gem_username: 'tester' })
+      allow(Octokit).to receive(:tags).with('puppetlabs/puppet-strings').and_return([{ name: '1' }])
+      PdkSync.main(steps: [:multi_gem_testing], args: { gem_name: 'puppet-strings', version_file: 'lib/puppet-strings/version.rb', build_gem: 'rake build', gem_path: 'pkg', gem_username: 'tester' })
       expect File.exist?("#{@output_path_gem}/pkg")
     end
   end

--- a/spec/utils_spec.rb
+++ b/spec/utils_spec.rb
@@ -110,9 +110,9 @@ describe 'PdkSync::Utils' do
   it '#self.setup_client' do
     g = double(PdkSync::GitPlatformClient)
     expect(PdkSync::GitPlatformClient).to receive(:new).with(:github,
-                                                             access_token: 'github-token',
+                                                             {access_token: 'github-token',
                                                              api_endpoint: nil,
-                                                             gitlab_api_endpoint: 'https://gitlab.com/api/v4').and_return(g)
+                                                             gitlab_api_endpoint: 'https://gitlab.com/api/v4'}).and_return(g)
     expect(PdkSync::Utils.setup_client).to eq(g)
   end
 


### PR DESCRIPTION
## Summary
Adds Ruby 3.x support to pdksync.

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [x] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
