### PR TITLE
(CONT-1214) - Exit pdksync on non-zero exit code

### DIFF
--- a/lib/pdksync.rb
+++ b/lib/pdksync.rb
@@ -174,14 +174,14 @@ module PdkSync
         next unless File.directory?(output_path)
         if steps.include?(:pdk_convert)
           exit_status = Utils.run_command(output_path, "#{Utils.return_pdk_path} convert --force #{configuration.templates}", nil)
+          break unless exit_status.zero?
           PdkSync::Logger.info 'converted'
-          next unless exit_status.zero?
         end
         if steps.include?(:pdk_validate)
           Dir.chdir(main_path) unless Dir.pwd == main_path
           exit_status = Utils.run_command(output_path, "#{Utils.return_pdk_path} validate -a", nil)
           PdkSync::Logger.info 'validated' if exit_status.zero?
-          next unless exit_status.zero?
+          break unless exit_status.zero?
         end
         if steps.include?(:run_a_command)
           Dir.chdir(main_path) unless Dir.pwd == main_path
@@ -191,7 +191,7 @@ module PdkSync
             next unless pid != 0 # rubocop:disable Metrics/BlockNesting
           else
             exit_status = Utils.run_command(output_path, module_args[:command], nil)
-            next unless exit_status.zero? # rubocop:disable Metrics/BlockNesting
+            break unless exit_status.zero? # rubocop:disable Metrics/BlockNesting
           end
         end
         if steps.include?(:gem_file_update)
@@ -214,7 +214,7 @@ module PdkSync
         end
         if steps.include?(:pdk_update)
           Dir.chdir(main_path) unless Dir.pwd == main_path
-          next unless Utils.pdk_update(output_path).zero?
+          break unless Utils.pdk_update(output_path).zero?
           if steps.include?(:use_pdk_ref)
             ref = Utils.return_template_ref(File.join(output_path, 'metadata.json'))
             pr_title = module_args[:additional_title] ? "#{module_args[:additional_title]} - pdksync_#{ref}" : "pdksync_#{ref}" # rubocop:disable Metrics/BlockNesting


### PR DESCRIPTION
## Summary
This change will now cause pdksync to exit if any fatal/error log messages are encountered during the execution.
Before it would move onto the next module and from the code seems to be the intended behaviour, so open to discussion if this is the way we want to go.

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Closes https://github.com/puppetlabs/pdksync/issues/171

## Checklist
- [x] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [x] Manually verified.
