### PR TITLE
Improve module validation performance

### DIFF
--- a/lib/pdksync.rb
+++ b/lib/pdksync.rb
@@ -161,7 +161,7 @@ module PdkSync
         repo_name = File.join(Utils.configuration.namespace, module_name)
         output_path = File.join(Utils.configuration.pdksync_dir, module_name)
         if steps.include?(:clone)
-          Utils.validate_modules_exist(client, module_names)
+          Utils.validate_modules_exist(client, [module_name])
           Utils.clean_env(output_path) if Dir.exist?(output_path)
           PdkSync::Logger.info 'delete module directory'
           @git_repo = Utils.clone_directory(Utils.configuration.namespace, module_name, output_path)


### PR DESCRIPTION
Validate that each module exists only once, as that module is being processed.

## Summary

During module cloning, the module validation function is called for all modules on each iteration
through the module list, resulting in the cloning taking much longer than it needs to.

This change adjusts the code to validate one module at a time as that module is being
processed.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [x] Manually verified.
