### PR TITLE
(maint) Remove unnecessary square bracket

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Pdksync
 
-[![Code Owners](https://img.shields.io/badge/owners-DevX--team-blue)](https://github.com/puppetlabs/pdksync/blob/main/CODEOWNERS)]
+[![Code Owners](https://img.shields.io/badge/owners-DevX--team-blue)](https://github.com/puppetlabs/pdksync/blob/main/CODEOWNERS)
 ![ci](https://github.com/puppetlabs/pdksync/actions/workflows/ci.yml/badge.svg)
 ![GitHub release (latest by date)](https://img.shields.io/github/v/release/puppetlabs/pdksync)
 


### PR DESCRIPTION
## Summary
Prior to this commit there is an additional square bracket that is not required: 

<img width="354" alt="Screenshot 2023-12-01 at 15 21 35" src="https://github.com/puppetlabs/pdksync/assets/20774767/baba1f68-f657-40e1-9b33-1b7ebde99104">

