### PR TITLE
pdksync - (CAT-1618) - Remove deprecated/obsolete codecov gem

### DIFF
--- a/pdksync.gemspec
+++ b/pdksync.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_development_dependency 'bundler'
-  spec.add_development_dependency 'codecov'
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'rubocop', '~> 0.50.0'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,11 +10,6 @@ if ENV['COVERAGE'] == 'yes'
       SimpleCov::Formatter::Console,
     ]
 
-    if ENV['CI'] == 'true'
-      require 'codecov'
-      SimpleCov.formatters << SimpleCov::Formatter::Codecov
-    end
-
     SimpleCov.start do
       track_files 'lib/**/*.rb'
       add_filter '/spec'
@@ -25,7 +20,7 @@ if ENV['COVERAGE'] == 'yes'
       add_filter '/.vendor'
     end
   rescue LoadError
-    raise 'Add the simplecov, simplecov-console, codecov gems to Gemfile to enable this task'
+    raise 'Add the simplecov & simplecov-console gems to Gemfile to enable this task'
   end
 end
 


### PR DESCRIPTION
(CAT-1618) - Remove deprecated/obsolete codecov gem
pdk version: `3.0.0` 
