### PR TITLE
Fix faraday warnings

### DIFF
--- a/pdksync.gemspec
+++ b/pdksync.gemspec
@@ -18,6 +18,8 @@ Gem::Specification.new do |spec|
   spec.test_files = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
+  spec.add_development_dependency 'faraday-retry'
+  spec.add_development_dependency 'faraday-multipart'
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'rspec'


### PR DESCRIPTION
When running pdksync rake tasks I get these faraday warnings:

```To use retry middleware with Faraday v2.0+, install `faraday-retry` gem
To use multipart middleware with Faraday v2.0+, install `faraday-multipart` gem; note: this is used by the ManageGHES client for uploading licenses```

To fix this I have added 'faraday-retry' and 'faraday-multipart' to the gemspec
