### PR TITLE
Ignore case when removing operating systems

### DIFF
--- a/lib/pdksync/utils.rb
+++ b/lib/pdksync/utils.rb
@@ -1166,7 +1166,7 @@ module PdkSync
       new_metadata_json = metadata_json(module_path)
       new_metadata_json[OPERATINGSYSTEM_SUPPORT].each do |os_vers|
         if (os = normalize_os(os_vers[OPERATINGSYSTEM]))
-          next unless os == os_to_remove
+          next unless os.downcase == os_to_remove.downcase
           vers = os_vers[OPERATINGSYSTEMRELEASE]
           next unless (ver_index = vers.find_index(version_to_remove))
           PdkSync::Logger.info "Removing #{os} #{vers[ver_index]} from metadata.json"

--- a/spec/pdksync_spec.rb
+++ b/spec/pdksync_spec.rb
@@ -152,6 +152,13 @@ describe PdkSync do
         PdkSync.main(steps: [:multi_gemfile_update], args: { gem_name: 'puppet-module', gemfury_username: 'tester' })
         expect File.exist?("#{@output_path_module}/Gemfile")
       end
+      it 'removes the specified platform from the metadata file' do
+        PdkSync::Utils.remove_platform_from_metadata('modules_pdksync/puppetlabs-motd', 'UbUNTU', '22.04')
+        metadata = JSON.parse(File.read('modules_pdksync/puppetlabs-motd/metadata.json'))
+        ubuntu_entry = metadata['operatingsystem_support'].find { |os| os['operatingsystem'] == 'Ubuntu' }
+        puts ubuntu_entry['operatingsystemrelease']
+        expect(ubuntu_entry['operatingsystemrelease']).not_to include('22.04')
+      end
     end
   end
   context 'main method' do


### PR DESCRIPTION
When running e.g. ```bundle exec rake 'pdksync:remove_platform_from_metadata[ubuntu, 18.04]'```
the os will not be removed from the metadata.json of a module due to the character casing not matching "Ubuntu"

To resolve this I have updated remove_platform_from_metadata so that when removing a platform the os character case is ignored