### PR TITLE
Implemented update os support

### DIFF
--- a/lib/pdksync/conf/supported_os_list.yaml
+++ b/lib/pdksync/conf/supported_os_list.yaml
@@ -1,0 +1,111 @@
+"operatingsystem_support":
+  [
+    {
+      "operatingsystem": "Windows",
+      "operatingsystemrelease": [
+        "2012", 
+        "2012 R2",
+        "2016",
+        "2019",
+        "2022",
+        "10",
+        "11"
+      ]
+    },
+    { 
+      "operatingsystem": "CentOS",
+      "operatingsystemrelease": [
+        "7",
+        "8"
+      ]
+    },
+    {
+      "operatingsystem": "OracleLinux",
+      "operatingsystemrelease": [
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "Scientific",
+      "operatingsystemrelease": [
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "SLES",
+      "operatingsystemrelease": [
+        "12",
+        "15"
+      ]
+    },
+    {
+      "operatingsystem": "Debian",
+      "operatingsystemrelease": [
+        "10",
+        "11"
+      ]
+    },
+    { 
+      "operatingsystem": "Fedora",
+      "operatingsystemrelease": [
+        "36"
+      ]
+    },
+    {
+      "operatingsystem": "OSX",
+      "operatingsystemrelease": [
+        "10.15",
+        "11",
+        "12"
+      ],
+    },
+    { 
+      "operatingsystem": "RedHat",
+      "operatingsystemrelease": [
+        "7",
+        "8",
+        "9"
+      ]
+    },
+    {
+      "operatingsystem": "Ubuntu",
+      "operatingsystemrelease": [
+        "18.04",
+        "20.04",
+        "22.04"
+      ],
+    },
+    {
+      "operatingsystem": "Solaris",
+      "operatingsystemrelease": [
+        "11"
+      ]
+    },
+    {
+      "operatingsystem": "AIX",
+      "operatingsystemrelease": [
+        "7.1",
+        "7.2"
+      ]
+    },
+    {
+      "operatingsystem": "Rocky",
+      "operatingsystemrelease": [
+        "8"
+      ]
+    },
+    {
+      "operatingsystem": "AlmaLinux",
+      "operatingsystemrelease": [
+        "8",
+        "9"
+      ]
+    },
+    {
+      "operatingsystem": "AmazonLinux",
+      "operatingsystemrelease": [
+        "2",
+        "2023"
+      ]
+    },
+  ]

--- a/lib/pdksync/utils.rb
+++ b/lib/pdksync/utils.rb
@@ -1153,6 +1153,21 @@ module PdkSync
     end
 
     # @summary
+    #   Updates the metadata.json to match the supported platforms in the supported_os_list.yaml
+    # @param module_path
+    #   Path to the root dir of the module
+    def self.update_os_support(module_path)
+      metadata_json = "#{module_path}/metadata.json"
+      raise 'Could not locate metadata.json' unless File.exist? metadata_json
+      new_metadata_json = JSON.parse(File.read(metadata_json))
+      supported_os_list = 'lib/pdksync/conf/supported_os_list.yaml'
+      supported_platforms = YAML.safe_load(File.read(supported_os_list))
+      new_metadata_json[OPERATINGSYSTEM_SUPPORT] = supported_platforms[OPERATINGSYSTEM_SUPPORT]
+      PdkSync::Logger.info 'Updating metadata.json'
+      write_metadata_json(module_path, new_metadata_json)
+    end
+
+    # @summary
     #   Removes the OS version from the supported platforms
     #   TODO: Remove entire OS entry when version is nil
     #   TODO: Remove entire OS entry when versions is empty


### PR DESCRIPTION
I noticed that the update_os_support task has no functionality so I have implemented this task

I added the new update_os_support method to utils.rb and a supported_os_list.yaml in the conf folder.

This update_os_support will update the operating systems supported in a module's metadata.json and update it to match the OSes in the supported_os_list