### PR TITLE
Updated run_command to not log when there is nothing to log

### DIFF
--- a/lib/pdksync/utils.rb
+++ b/lib/pdksync/utils.rb
@@ -247,7 +247,7 @@ module PdkSync
         else
           stdout, stderr, status = Open3.capture3(command)
         end
-        PdkSync::Logger.info "\n#{stdout}\n"
+        PdkSync::Logger.info "\n#{stdout}\n" unless stdout.empty?
         PdkSync::Logger.error "Unable to run command '#{command}': #{stderr}" unless status.exitstatus.zero?
         status.exitstatus
       else


### PR DESCRIPTION
When running the run_tests_locally rake tasks I noticed unnecessary whitespace when stdout has nothing to log.
I have updated run_command in utils so that stdout will not log when there is nothing to log 

Before
```
INFO - PdkSync: puppetlabs-chocolatey, 
INFO - PdkSync: Run tests 
INFO - PdkSync: 


INFO - PdkSync: 


[DEPRECATED] `Bundler.with_clean_env` has been deprecated in favor of `Bundler.with_unbundled_env`. If you instead want the environment before bundler was originally loaded, use `Bundler.with_original_env` (called at /Users/alex.patterson/Library/CloudStorage/OneDrive-PERFORCESOFTWARE,INC/Desktop/pdksync/lib/pdksync/utils.rb:256)
INFO - PdkSync: SUCCESS:Kicking of module Acceptance tests to run for the module puppetlabs-chocolatey - SUCCEED.Results will be available in the following path modules_pdksync/puppetlabs-chocolatey/litmusacceptance.out.Process id is 70058
INFO - PdkSync: done
INFO - PdkSync: puppetlabs-concat, 
INFO - PdkSync: Run tests 
INFO - PdkSync: 


INFO - PdkSync: 


INFO - PdkSync: SUCCESS:Kicking of module Acceptance tests to run for the module puppetlabs-concat - SUCCEED.Results will be available in the following path modules_pdksync/puppetlabs-concat/litmusacceptance.out.Process id is 70064
INFO - PdkSync: done
```

After
```
INFO - PdkSync: puppetlabs-chocolatey, 
INFO - PdkSync: Run tests 
[DEPRECATED] `Bundler.with_clean_env` has been deprecated in favor of `Bundler.with_unbundled_env`. If you instead want the environment before bundler was originally loaded, use `Bundler.with_original_env` (called at /Users/alex.patterson/Library/CloudStorage/OneDrive-PERFORCESOFTWARE,INC/Desktop/pdksync/lib/pdksync/utils.rb:256)
INFO - PdkSync: SUCCESS:Kicking of module Acceptance tests to run for the module puppetlabs-chocolatey - SUCCEED.Results will be available in the following path modules_pdksync/puppetlabs-chocolatey/litmusacceptance.out.Process id is 72844
INFO - PdkSync: done
INFO - PdkSync: puppetlabs-concat, 
INFO - PdkSync: Run tests 
INFO - PdkSync: SUCCESS:Kicking of module Acceptance tests to run for the module puppetlabs-concat - SUCCEED.Results will be available in the following path modules_pdksync/puppetlabs-concat/litmusacceptance.out.Process id is 72851
INFO - PdkSync: done
```