### PR TITLE
Throw an error if litmusacceptance.out doesn't exist

### DIFF
--- a/lib/pdksync/utils.rb
+++ b/lib/pdksync/utils.rb
@@ -625,6 +625,7 @@ module PdkSync
       Dir.chdir(old_path)
       unless File.exist?("#{output_path}/litmusacceptance.out")
         PdkSync::Logger.fatal "File #{output_path}/litmusacceptance.out does not exist."
+        exit(1)
       end
 
       lines = IO.readlines("#{output_path}/litmusacceptance.out")[-10..-1]

--- a/lib/pdksync/utils.rb
+++ b/lib/pdksync/utils.rb
@@ -624,8 +624,7 @@ module PdkSync
       # Run the tests
       Dir.chdir(old_path)
       unless File.exist?("#{output_path}/litmusacceptance.out")
-        PdkSync::Logger.fatal "File #{output_path}/litmusacceptance.out does not exist."
-        exit(1)
+        raise "FATAL - File #{output_path}/litmusacceptance.out does not exist.".red
       end
 
       lines = IO.readlines("#{output_path}/litmusacceptance.out")[-10..-1]

--- a/lib/pdksync/utils.rb
+++ b/lib/pdksync/utils.rb
@@ -623,6 +623,10 @@ module PdkSync
 
       # Run the tests
       Dir.chdir(old_path)
+      unless File.exist?("#{output_path}/litmusacceptance.out")
+        PdkSync::Logger.fatal "File #{output_path}/litmusacceptance.out does not exist."
+      end
+
       lines = IO.readlines("#{output_path}/litmusacceptance.out")[-10..-1]
       if lines.find { |e| %r{exit} =~ e } # rubocop:disable Style/ConditionalAssignment
         report_rows << if lines.find { |e| %r{^Failed} =~ e } || lines.find { |e| %r{--trace} =~ e }

--- a/spec/pdksync_spec.rb
+++ b/spec/pdksync_spec.rb
@@ -110,6 +110,9 @@ describe PdkSync do
     it 'raise when run_tests with no arguments' do
       expect { PdkSync.main(steps: [:run_tests_locally]) }.to raise_error(NoMethodError) # , %r{run_tests" requires arguments (module_type) to run.})
     end
+    it 'raise when litmusacceptance.out does not exist' do
+      expect { PdkSync::Utils.fetch_test_results_locally('modules_pdksync/puppetlabs-motd', 'litmus', 'puppetlabs-motd', []) }.to raise_error(RuntimeError, %r{FATAL - File modules_pdksync/puppetlabs-motd/litmusacceptance.out does not exist.})
+    end
     it 'raise when run_tests_jenkins with no arguments' do
       allow(ENV).to receive(:[]).with('JENKINS_USERNAME').and_return('JENKINS_USERNAME')
       allow(ENV).to receive(:[]).with('JENKINS_PASSWORD').and_return('JENKINS_PASSWORD')


### PR DESCRIPTION
When fetching tests locally I have added an error warning to make it more obvious when litmusacceptance.out doesn't exist, and cleaned up the error output

Before
```
INFO - PdkSync: puppetlabs-lvm, 
INFO - PdkSync: Fetch test results for local run 
WARN - PdkSync: (WARNING) Fetching test results locally supports only for litmus'
rake aborted!
Errno::ENOENT: No such file or directory @ rb_sysopen - modules_pdksync/puppetlabs-lvm/litmusacceptance.out (Errno::ENOENT)
/Users/alex.patterson/Library/CloudStorage/OneDrive-PERFORCESOFTWARE,INC/Desktop/pdksync/lib/pdksync/utils.rb:626:in `readlines'
/Users/alex.patterson/Library/CloudStorage/OneDrive-PERFORCESOFTWARE,INC/Desktop/pdksync/lib/pdksync/utils.rb:626:in `fetch_test_results_locally'
/Users/alex.patterson/Library/CloudStorage/OneDrive-PERFORCESOFTWARE,INC/Desktop/pdksync/lib/pdksync.rb:213:in `block in main'
/Users/alex.patterson/Library/CloudStorage/OneDrive-PERFORCESOFTWARE,INC/Desktop/pdksync/lib/pdksync.rb:157:in `each'
/Users/alex.patterson/Library/CloudStorage/OneDrive-PERFORCESOFTWARE,INC/Desktop/pdksync/lib/pdksync.rb:157:in `main'
/Users/alex.patterson/Library/CloudStorage/OneDrive-PERFORCESOFTWARE,INC/Desktop/pdksync/lib/pdksync/rake_tasks.rb:58:in `block (2 levels) in <top (required)>'
/Users/alex.patterson/Library/CloudStorage/OneDrive-PERFORCESOFTWARE,INC/Desktop/pdksync/.bundle/gems/ruby/3.2.0/gems/rake-13.2.1/exe/rake:27:in `<top (required)>'
/Users/alex.patterson/.rbenv/versions/3.2.4/bin/bundle:25:in `load'
/Users/alex.patterson/.rbenv/versions/3.2.4/bin/bundle:25:in `<main>'
Tasks: TOP => pdksync:fetch_test_results_locally
(See full trace by running task with --trace)
```

After
```
INFO - PdkSync: puppetlabs-lvm, 
INFO - PdkSync: Fetch test results for local run 
WARN - PdkSync: (WARNING) Fetching test results locally supports only for litmus'
FATAL - PdkSync: File modules_pdksync/puppetlabs-lvm/litmusacceptance.out does not exist.
```