### PR TITLE
Throw error if jenkins test results do not exist

### DIFF
--- a/lib/pdksync.rb
+++ b/lib/pdksync.rb
@@ -309,7 +309,6 @@ module PdkSync
         if steps.include?(:test_results_jenkins)
           unless File.exist?("results_#{module_name}.out")
             PdkSync::Logger.fatal "results_#{module_name}.out does not exist"
-            exit(1)
           end
           Dir.chdir(main_path) unless Dir.pwd == main_path
           PdkSync::Logger.info 'Fetch test results from jenkins, '

--- a/lib/pdksync.rb
+++ b/lib/pdksync.rb
@@ -307,6 +307,10 @@ module PdkSync
           end
         end
         if steps.include?(:test_results_jenkins)
+          unless File.exist?("results_#{module_name}.out")
+            PdkSync::Logger.fatal "results_#{module_name}.out does not exist"
+            exit(1)
+          end
           Dir.chdir(main_path) unless Dir.pwd == main_path
           PdkSync::Logger.info 'Fetch test results from jenkins, '
           module_type = Utils.module_type(output_path, module_name)


### PR DESCRIPTION
When running the pdksync:test_results_jenkins task I have added a error log to make it more obvious that the results_puppetlabs-lvm.out does not exist