### PR TITLE
(CAT-2281) Remove puppet 7 infrastructure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,6 @@ jobs:
       fail-fast: false
       matrix:
         ruby_version:
-          - '2.7'
           - '3.2'
     name: "spec (ruby ${{ matrix.ruby_version }})"
     uses: "puppetlabs/cat-github-actions/.github/workflows/gem_ci.yml@main"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -12,7 +12,6 @@ jobs:
       fail-fast: false
       matrix:
         ruby_version:
-          - '2.7'
           - '3.2'
     name: "spec (ruby ${{ matrix.ruby_version }})"
     uses: "puppetlabs/cat-github-actions/.github/workflows/gem_ci.yml@main"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,7 +9,7 @@ AllCops:
   DisplayCopNames: true
   ExtraDetails: true
   DisplayStyleGuide: true
-  TargetRubyVersion: '2.7'
+  TargetRubyVersion: '3.1'
   Include:
     - "./**/*.rb"
   Exclude:

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Pdksync by default expects that your Puppet module repositories live on GitHub a
 
 ### Requirements
 --------
-* Ruby >= 2.7
+* Ruby >= 3.1
 * Bundler >= 1.15
 * Obtain a forge api access key so that pdksync can access the puppetcore gems.  This key will be referenced below as the `PUPPET_FORGE_TOKEN`.  For more information see [Puppet Documentation](https://www.puppet.com/docs/puppet/8/system_requirements#plan_requirements) and the [dev.to blog](https://dev.to/puppet/lets-get-started-with-puppet-core-3p5j).
 

--- a/pdksync.gemspec
+++ b/pdksync.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
   spec.description = 'Utility to synchronize common files across puppet modules using PDK Update.'
   spec.homepage = 'http://github.com/puppetlabs/pdksync'
   spec.license = 'Apache-2.0'
-  spec.required_ruby_version = '>= 2.7'
+  spec.required_ruby_version = '>= 3.1.0'
 
   spec.files = `git ls-files -z`.split("\x0")
   spec.executables = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }


### PR DESCRIPTION
Puppet 7 is EOL. Therefore, we can remove the test infrastructure for it. This commit aims to clear up any testing/config infrastructure related to Puppet 7 and, by extension, Ruby 2.7.

