### PR TITLE
(CAT-2453) Bump Rubocop versions in order to remove rexml

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,9 +1,12 @@
 ---
 inherit_from: .rubocop_todo.yml
 
-require:
-- rubocop-performance
-- rubocop-rspec
+plugins: 
+  - rubocop-rspec
+  - rubocop-rspec_rails
+  - rubocop-performance
+  - rubocop-factory_bot
+  - rubocop-capybara
 AllCops:
   NewCops: enable
   DisplayCopNames: true
@@ -21,7 +24,7 @@ AllCops:
     - spec/fixtures/**/*
     - vendor/**/*
     - modules_pdksync/**/*
-Metrics/LineLength:
+Layout/LineLength:
   Description: People have wide screens, use them.
   Max: 235
 Style/BlockDelimiters:

--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,10 @@ group :development do
 end
 
 group :rubocop do
-    gem 'rubocop', '~> 1.64.0',           require: false
-    gem 'rubocop-rspec', '~> 3.0',       require: false
-    gem 'rubocop-performance', '~> 1.16', require: false
+  gem "rubocop", '~> 1.73.0',                    require: false
+  gem "rubocop-performance", '~> 1.24.0',        require: false
+  gem "rubocop-rspec", '~> 3.5.0',               require: false
+  gem "rubocop-rspec_rails", '~> 2.31.0',        require: false
+  gem "rubocop-factory_bot", '~> 2.27.0',        require: false
+  gem "rubocop-capybara", '~> 2.22.0',           require: false
 end


### PR DESCRIPTION
## Summary

The version of rexml brought in by the current rubocop versions has a security vulnerability. Updating to these rubocop versions will remove their dependency entirely. Adding in plugins that where previously part of the default package, but have been split off since our previously used version.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
