### PR TITLE
(CAT-2456) Fix spec tests

### DIFF
--- a/pdksync.gemspec
+++ b/pdksync.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'rspec'
-  spec.add_development_dependency 'rubocop', '~> 0.50.0'
+  spec.add_development_dependency 'rubocop'
   spec.add_development_dependency 'simplecov'
   spec.add_development_dependency 'simplecov-console'
   spec.add_runtime_dependency 'pdk', '>= 1.14.1'


### PR DESCRIPTION
Both the gemspec and the Gemfile are specifying rubocop as a development depedency.  The Gemfile and the gemspec are not in line.  This removes the version from the gemspec and fixes the warning.

Signed-off-by: Gavin Didrichsen <gavin.didrichsen@gmail.com>

## Summary
Provide a detailed description of all the changes present in this pull request.

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
